### PR TITLE
Automatically scaling underlying WebGL canvas

### DIFF
--- a/packages/fim-browser/src/__tests__/CommonSuites.browser.ts
+++ b/packages/fim-browser/src/__tests__/CommonSuites.browser.ts
@@ -54,15 +54,15 @@ engineOptions.showTracing = showTracing;
 engineOptions.showWarnings = showWarnings;
 
 TestSuites.coreCanvas2D('CoreBrowserDomCanvas2D',
-  (canvasOptions, dimensions) => new CoreBrowserDomCanvas2D(canvasOptions, dimensions, 'UnitTest', engineOptions));
+  (dimensions, canvasOptions) => new CoreBrowserDomCanvas2D(dimensions, canvasOptions, 'UnitTest', engineOptions));
 
 TestSuites.coreCanvasWebGL('CoreBrowserDomCanvasWebGL',
-  (canvasOptions, dimensions) => new CoreBrowserDomCanvasWebGL(canvasOptions, dimensions, 'UnitTest', engineOptions));
+  (dimensions, canvasOptions) => new CoreBrowserDomCanvasWebGL(dimensions, canvasOptions, 'UnitTest', engineOptions));
 
 TestSuites.coreCanvas2D('CoreBrowserOffscreenCanvas2D',
-  (canvasOptions, dimensions) => new CoreBrowserOffscreenCanvas2D(canvasOptions, dimensions, 'UnitTest',
+  (dimensions, canvasOptions) => new CoreBrowserOffscreenCanvas2D(dimensions, canvasOptions, 'UnitTest',
     engineOptions));
 
 TestSuites.coreCanvasWebGL('CoreBrowserOffscreenCanvasWebGL',
-  (canvasOptions, dimensions) => new CoreBrowserOffscreenCanvasWebGL(canvasOptions, dimensions, 'UnitTest',
+  (dimensions, canvasOptions) => new CoreBrowserOffscreenCanvasWebGL(dimensions, canvasOptions, 'UnitTest',
     engineOptions));

--- a/packages/fim-browser/src/__tests__/CommonSuites.browser.ts
+++ b/packages/fim-browser/src/__tests__/CommonSuites.browser.ts
@@ -15,16 +15,16 @@ import { TestSuites } from '@leosingleton/fim-common-tests';
 const showTracing = false;
 const showWarnings = false;
 
-TestSuites.fim('FimBrowserFactory with OffscreenCanvas enabled (debug mode)', (maxImageDimensions) => {
-  const fim = FimBrowserFactory.create(maxImageDimensions);
+TestSuites.fim('FimBrowserFactory with OffscreenCanvas enabled (debug mode)', () => {
+  const fim = FimBrowserFactory.create();
   fim.engineOptions.debugMode = true;
   fim.engineOptions.showTracing = showTracing;
   fim.engineOptions.showWarnings = showWarnings;
   return fim;
 });
 
-TestSuites.fim('FimBrowserFactory with OffscreenCanvas disabled (debug mode)', (maxImageDimensions) => {
-  const fim = FimBrowserFactory.create(maxImageDimensions);
+TestSuites.fim('FimBrowserFactory with OffscreenCanvas disabled (debug mode)', () => {
+  const fim = FimBrowserFactory.create();
   fim.engineOptions.debugMode = true;
   fim.engineOptions.disableOffscreenCanvas = true;
   fim.engineOptions.showTracing = showTracing;
@@ -32,15 +32,15 @@ TestSuites.fim('FimBrowserFactory with OffscreenCanvas disabled (debug mode)', (
   return fim;
 });
 
-TestSuites.fim('FimBrowserFactory with OffscreenCanvas enabled', (maxImageDimensions) => {
-  const fim = FimBrowserFactory.create(maxImageDimensions);
+TestSuites.fim('FimBrowserFactory with OffscreenCanvas enabled', () => {
+  const fim = FimBrowserFactory.create();
   fim.engineOptions.showTracing = showTracing;
   fim.engineOptions.showWarnings = showWarnings;
   return fim;
 });
 
-TestSuites.fim('FimBrowserFactory with OffscreenCanvas disabled', (maxImageDimensions) => {
-  const fim = FimBrowserFactory.create(maxImageDimensions);
+TestSuites.fim('FimBrowserFactory with OffscreenCanvas disabled', () => {
+  const fim = FimBrowserFactory.create();
   fim.engineOptions.disableOffscreenCanvas = true;
   fim.engineOptions.showTracing = showTracing;
   fim.engineOptions.showWarnings = showWarnings;

--- a/packages/fim-browser/src/__tests__/ExportToCanvas.browser.ts
+++ b/packages/fim-browser/src/__tests__/ExportToCanvas.browser.ts
@@ -78,7 +78,7 @@ describe('Exports to Canvas', () => {
       const dim = FimDimensions.fromWidthHeight(302, 298);
 
       // Create a FIM image and fill it with blue
-      const image = fim.createImage({}, dim);
+      const image = fim.createImage(dim);
       await image.fillSolidAsync(TestColors.blue);
 
       // Create an oversized canvas and fill with red

--- a/packages/fim-browser/src/__tests__/ExportToCanvas.browser.ts
+++ b/packages/fim-browser/src/__tests__/ExportToCanvas.browser.ts
@@ -50,7 +50,7 @@ function getPixel(context: CanvasRenderingContext2D, x: number, y: number): FimC
 describe('Exports to Canvas', () => {
 
   it('exportToCanvasAsync()', async () => {
-    await usingAsync(FimBrowserFactory.create(TestSizes.mediumSquare), async fim => {
+    await usingAsync(FimBrowserFactory.create(), async fim => {
       // Create a FIM image and fill it with blue
       const image = fim.createImage(TestSizes.mediumSquare);
       await image.fillSolidAsync(TestColors.blue);
@@ -74,7 +74,7 @@ describe('Exports to Canvas', () => {
   });
 
   it('exportToCanvasAsync() with downscale', async () => {
-    await usingAsync(FimBrowserFactory.create(TestSizes.mediumSquare), async fim => {
+    await usingAsync(FimBrowserFactory.create(), async fim => {
       const dim = FimDimensions.fromWidthHeight(302, 298);
 
       // Create a FIM image and fill it with blue

--- a/packages/fim-browser/src/__tests__/ExportToCanvas.browser.ts
+++ b/packages/fim-browser/src/__tests__/ExportToCanvas.browser.ts
@@ -52,7 +52,7 @@ describe('Exports to Canvas', () => {
   it('exportToCanvasAsync()', async () => {
     await usingAsync(FimBrowserFactory.create(TestSizes.mediumSquare), async fim => {
       // Create a FIM image and fill it with blue
-      const image = fim.createImage();
+      const image = fim.createImage(TestSizes.mediumSquare);
       await image.fillSolidAsync(TestColors.blue);
 
       // Create a 100x100 canvas and fill with red

--- a/packages/fim-browser/src/__tests__/PngJpeg.browser.ts
+++ b/packages/fim-browser/src/__tests__/PngJpeg.browser.ts
@@ -12,7 +12,7 @@ const sampleJpeg = `${sampleImagesUrl}/four-squares.jpg`;
 describe('Loads from PNG and JPEG URLs', () => {
 
   it('createImageFromPngFileAsync()', async () => {
-    await usingAsync(FimBrowserFactory.create(TestSizes.smallSquare), async fim => {
+    await usingAsync(FimBrowserFactory.create(), async fim => {
       // Load the four squares test pattern by URL
       const image = await fim.createImageFromPngFileAsync(samplePng);
 
@@ -22,7 +22,7 @@ describe('Loads from PNG and JPEG URLs', () => {
   });
 
   it('createImageFromJpegFileAsync()', async () => {
-    await usingAsync(FimBrowserFactory.create(TestSizes.smallSquare), async fim => {
+    await usingAsync(FimBrowserFactory.create(), async fim => {
       // Load the four squares test pattern by URL
       const image = await fim.createImageFromJpegFileAsync(sampleJpeg);
 
@@ -32,7 +32,7 @@ describe('Loads from PNG and JPEG URLs', () => {
   });
 
   it('loadFromPngFileAsync()', async () => {
-    await usingAsync(FimBrowserFactory.create(TestSizes.smallSquare), async fim => {
+    await usingAsync(FimBrowserFactory.create(), async fim => {
       // Load the four squares test pattern by URL
       const image = fim.createImage(TestSizes.smallSquare);
       await image.loadFromPngFileAsync(samplePng);
@@ -43,7 +43,7 @@ describe('Loads from PNG and JPEG URLs', () => {
   });
 
   it('loadFromJpegFileAsync()', async () => {
-    await usingAsync(FimBrowserFactory.create(TestSizes.smallSquare), async fim => {
+    await usingAsync(FimBrowserFactory.create(), async fim => {
       // Load the four squares test pattern by URL
       const image = fim.createImage(TestSizes.smallSquare);
       await image.loadFromJpegFileAsync(sampleJpeg);

--- a/packages/fim-browser/src/__tests__/PngJpeg.browser.ts
+++ b/packages/fim-browser/src/__tests__/PngJpeg.browser.ts
@@ -34,7 +34,7 @@ describe('Loads from PNG and JPEG URLs', () => {
   it('loadFromPngFileAsync()', async () => {
     await usingAsync(FimBrowserFactory.create(TestSizes.smallSquare), async fim => {
       // Load the four squares test pattern by URL
-      const image = fim.createImage();
+      const image = fim.createImage(TestSizes.smallSquare);
       await image.loadFromPngFileAsync(samplePng);
 
       // Validate the test pattern
@@ -45,7 +45,7 @@ describe('Loads from PNG and JPEG URLs', () => {
   it('loadFromJpegFileAsync()', async () => {
     await usingAsync(FimBrowserFactory.create(TestSizes.smallSquare), async fim => {
       // Load the four squares test pattern by URL
-      const image = fim.createImage();
+      const image = fim.createImage(TestSizes.smallSquare);
       await image.loadFromJpegFileAsync(sampleJpeg);
 
       // Validate the test pattern

--- a/packages/fim-browser/src/core/CoreBrowserDomCanvas2D.ts
+++ b/packages/fim-browser/src/core/CoreBrowserDomCanvas2D.ts
@@ -10,9 +10,9 @@ import { CoreCanvas2D, CoreCanvasOptions, CoreMimeType, RenderingContext2D } fro
 
 /** Wrapper around the HTML DOM canvas */
 export class CoreBrowserDomCanvas2D extends CoreBrowserCanvas2D {
-  public constructor(canvasOptions: CoreCanvasOptions, dimensions: FimDimensions, handle: string,
+  public constructor(dimensions: FimDimensions, canvasOptions: CoreCanvasOptions, handle: string,
       engineOptions?: FimEngineOptions) {
-    super(loadFromFileAsync, canvasOptions, dimensions, handle, engineOptions);
+    super(loadFromFileAsync, dimensions, canvasOptions, handle, engineOptions);
 
     // Create a hidden canvas
     const canvas = CoreBrowserDomCanvas2D.canvasPool.getCanvas();
@@ -43,9 +43,9 @@ export class CoreBrowserDomCanvas2D extends CoreBrowserCanvas2D {
     return this.canvasElement.getContext('2d');
   }
 
-  protected createCanvas2D(canvasOptions: CoreCanvasOptions, dimensions: FimDimensions, handle: string,
+  protected createCanvas2D(dimensions: FimDimensions, canvasOptions: CoreCanvasOptions, handle: string,
       engineOptions: FimEngineOptions): CoreCanvas2D {
-    return new CoreBrowserDomCanvas2D(canvasOptions, dimensions, handle, engineOptions);
+    return new CoreBrowserDomCanvas2D(dimensions, canvasOptions, handle, engineOptions);
   }
 
   protected convertToBlobAsync(type: CoreMimeType, quality?: number): Promise<Blob> {

--- a/packages/fim-browser/src/core/CoreBrowserDomCanvasWebGL.ts
+++ b/packages/fim-browser/src/core/CoreBrowserDomCanvasWebGL.ts
@@ -11,9 +11,9 @@ import { CoreCanvas2D, CoreCanvasOptions, CoreCanvasWebGL, CoreTextureOptions,
 
 /** Wrapper around the HTML DOM canvas */
 export class CoreBrowserDomCanvasWebGL extends CoreCanvasWebGL {
-  public constructor(canvasOptions: CoreCanvasOptions, dimensions: FimDimensions, handle: string,
+  public constructor(dimensions: FimDimensions, canvasOptions: CoreCanvasOptions, handle: string,
       engineOptions?: FimEngineOptions) {
-    super(canvasOptions, dimensions, handle, engineOptions);
+    super(dimensions, canvasOptions, handle, engineOptions);
 
     // Create a hidden canvas
     const canvas = CoreBrowserDomCanvasWebGL.canvasPool.getCanvas();
@@ -45,14 +45,14 @@ export class CoreBrowserDomCanvasWebGL extends CoreCanvasWebGL {
     return this.canvasElement.getContext('webgl');
   }
 
-  protected createCanvas2D(canvasOptions: CoreCanvasOptions, dimensions: FimDimensions, handle: string,
+  protected createCanvas2D(dimensions: FimDimensions, canvasOptions: CoreCanvasOptions, handle: string,
       engineOptions: FimEngineOptions): CoreCanvas2D {
-    return new CoreBrowserDomCanvas2D(canvasOptions, dimensions, handle, engineOptions);
+    return new CoreBrowserDomCanvas2D(dimensions, canvasOptions, handle, engineOptions);
   }
 
-  protected createCoreTextureInternal(parent: CoreCanvasWebGL, options: CoreTextureOptions, dimensions: FimDimensions,
+  protected createCoreTextureInternal(parent: CoreCanvasWebGL, dimensions: FimDimensions, options: CoreTextureOptions,
       handle: string): CoreBrowserTexture {
-    return new CoreBrowserTexture(parent, options, dimensions, handle);
+    return new CoreBrowserTexture(parent, dimensions, options, handle);
   }
 
   protected addCanvasEventListener(type: string, listener: EventListenerObject, options: boolean): void {

--- a/packages/fim-browser/src/core/CoreBrowserOffscreenCanvas2D.ts
+++ b/packages/fim-browser/src/core/CoreBrowserOffscreenCanvas2D.ts
@@ -12,9 +12,9 @@ import { CoreCanvas2D, CoreCanvasOptions, CoreMimeType, RenderingContext2D } fro
 
 /** Wrapper around the browser's OffscreenCanvas */
 export class CoreBrowserOffscreenCanvas2D extends CoreBrowserCanvas2D {
-  public constructor(canvasOptions: CoreCanvasOptions, dimensions: FimDimensions, handle: string,
+  public constructor(dimensions: FimDimensions, canvasOptions: CoreCanvasOptions, handle: string,
       engineOptions?: FimEngineOptions) {
-    super(loadFromFileAsync, canvasOptions, dimensions, handle, engineOptions);
+    super(loadFromFileAsync, dimensions, canvasOptions, handle, engineOptions);
     this.canvasElement = new OffscreenCanvas(dimensions.w, dimensions.h);
   }
 
@@ -37,9 +37,9 @@ export class CoreBrowserOffscreenCanvas2D extends CoreBrowserCanvas2D {
     return this.canvasElement.getContext('2d');
   }
 
-  protected createCanvas2D(canvasOptions: CoreCanvasOptions, dimensions: FimDimensions, handle: string,
+  protected createCanvas2D(dimensions: FimDimensions, canvasOptions: CoreCanvasOptions, handle: string,
       engineOptions: FimEngineOptions): CoreCanvas2D {
-    return new CoreBrowserOffscreenCanvas2D(canvasOptions, dimensions, handle, engineOptions);
+    return new CoreBrowserOffscreenCanvas2D(dimensions, canvasOptions, handle, engineOptions);
   }
 
   protected convertToBlobAsync(type: CoreMimeType, quality?: number): Promise<Blob> {

--- a/packages/fim-browser/src/core/CoreBrowserOffscreenCanvasWebGL.ts
+++ b/packages/fim-browser/src/core/CoreBrowserOffscreenCanvasWebGL.ts
@@ -13,9 +13,9 @@ import { CoreCanvas2D, CoreCanvasOptions, CoreCanvasWebGL, CoreTextureOptions,
 
 /** Wrapper around the browser's OffscreenCanvas */
 export class CoreBrowserOffscreenCanvasWebGL extends CoreCanvasWebGL {
-  public constructor(canvasOptions: CoreCanvasOptions, dimensions: FimDimensions, handle: string,
+  public constructor(dimensions: FimDimensions, canvasOptions: CoreCanvasOptions, handle: string,
       engineOptions?: FimEngineOptions) {
-    super(canvasOptions, dimensions, handle, engineOptions);
+    super(dimensions, canvasOptions, handle, engineOptions);
     this.canvasElement = new OffscreenCanvas(dimensions.w, dimensions.h);
 
     this.finishInitialization();
@@ -39,14 +39,14 @@ export class CoreBrowserOffscreenCanvasWebGL extends CoreCanvasWebGL {
     return this.canvasElement.getContext('webgl');
   }
 
-  protected createCanvas2D(canvasOptions: CoreCanvasOptions, dimensions: FimDimensions, handle: string,
+  protected createCanvas2D(dimensions: FimDimensions, canvasOptions: CoreCanvasOptions, handle: string,
       engineOptions: FimEngineOptions): CoreCanvas2D {
-    return new CoreBrowserOffscreenCanvas2D(canvasOptions, dimensions, handle, engineOptions);
+    return new CoreBrowserOffscreenCanvas2D(dimensions, canvasOptions, handle, engineOptions);
   }
 
-  protected createCoreTextureInternal(parent: CoreCanvasWebGL, options: CoreTextureOptions, dimensions: FimDimensions,
+  protected createCoreTextureInternal(parent: CoreCanvasWebGL, dimensions: FimDimensions, options: CoreTextureOptions,
       handle: string): CoreBrowserTexture {
-    return new CoreBrowserTexture(parent, options, dimensions, handle);
+    return new CoreBrowserTexture(parent, dimensions, options, handle);
   }
 
   protected addCanvasEventListener(type: string, listener: EventListenerObject, options: boolean): void {

--- a/packages/fim-browser/src/core/FileReader.ts
+++ b/packages/fim-browser/src/core/FileReader.ts
@@ -9,7 +9,7 @@ import { FimError, FimErrorCode } from '@leosingleton/fim';
  * @param url URL of the file to download
  * @returns File contents, as a `Uint8Array`
  */
-export async function fileReader(url: string): Promise<Uint8Array> {
+export async function fileReaderAsync(url: string): Promise<Uint8Array> {
   const fetchResponse = await fetch(url);
   if (!fetchResponse.ok) {
     throw new FimError(FimErrorCode.FetchError, `${url}: ${fetchResponse.status} ${fetchResponse.statusText}`);

--- a/packages/fim-browser/src/engine/BrowserEngineFim.ts
+++ b/packages/fim-browser/src/engine/BrowserEngineFim.ts
@@ -8,7 +8,7 @@ import { CoreBrowserDomCanvas2D } from '../core/CoreBrowserDomCanvas2D';
 import { CoreBrowserDomCanvasWebGL } from '../core/CoreBrowserDomCanvasWebGL';
 import { CoreBrowserOffscreenCanvas2D } from '../core/CoreBrowserOffscreenCanvas2D';
 import { CoreBrowserOffscreenCanvasWebGL } from '../core/CoreBrowserOffscreenCanvasWebGL';
-import { fileReader } from '../core/FileReader';
+import { fileReaderAsync } from '../core/FileReader';
 import { loadFromFileAsync } from '../core/ImageLoader';
 import { FimDimensions, FimImageOptions, FimObject } from '@leosingleton/fim';
 import { CoreCanvas2D, CoreCanvasOptions, CoreCanvasWebGL, EngineFimBase,
@@ -22,7 +22,7 @@ export class BrowserEngineFim extends EngineFimBase<BrowserEngineImage, EngineSh
    * @param name An optional name specified when creating the object to help with debugging
    */
   public constructor(name?: string) {
-    super(fileReader, loadFromFileAsync, name);
+    super(fileReaderAsync, loadFromFileAsync, name);
   }
 
   protected createEngineImage(parent: FimObject, dimensions: FimDimensions, options: FimImageOptions, name?: string):

--- a/packages/fim-browser/src/engine/BrowserEngineFim.ts
+++ b/packages/fim-browser/src/engine/BrowserEngineFim.ts
@@ -19,12 +19,10 @@ import { GlslShader } from 'webpack-glsl-minify';
 export class BrowserEngineFim extends EngineFimBase<BrowserEngineImage, EngineShader> implements FimBrowser {
   /**
    * Constructor
-   * @param maxImageDimensions Maximum dimensions of any image. If unspecified, defaults to the maximum image size
-   *    supported by the WebGL capabilities of the browser and GPU.
    * @param name An optional name specified when creating the object to help with debugging
    */
-  public constructor(maxImageDimensions?: FimDimensions, name?: string) {
-    super(fileReader, loadFromFileAsync, maxImageDimensions, name);
+  public constructor(name?: string) {
+    super(fileReader, loadFromFileAsync, name);
   }
 
   protected createEngineImage(parent: FimObject, dimensions: FimDimensions, options: FimImageOptions, name?: string):

--- a/packages/fim-browser/src/engine/BrowserEngineFim.ts
+++ b/packages/fim-browser/src/engine/BrowserEngineFim.ts
@@ -27,9 +27,9 @@ export class BrowserEngineFim extends EngineFimBase<BrowserEngineImage, EngineSh
     super(fileReader, loadFromFileAsync, maxImageDimensions, name);
   }
 
-  protected createEngineImage(parent: FimObject, options: FimImageOptions, dimensions: FimDimensions, name?: string):
+  protected createEngineImage(parent: FimObject, dimensions: FimDimensions, options: FimImageOptions, name?: string):
       BrowserEngineImage {
-    return new BrowserEngineImage(parent, options, dimensions, name);
+    return new BrowserEngineImage(parent, dimensions, options, name);
   }
 
   protected createEngineGLShader(parent: FimObject, fragmentShader: GlslShader, vertexShader?: GlslShader,
@@ -37,19 +37,19 @@ export class BrowserEngineFim extends EngineFimBase<BrowserEngineImage, EngineSh
     return new EngineShader(parent, fragmentShader, vertexShader, name);
   }
 
-  public createCoreCanvas2D(options: CoreCanvasOptions, dimensions: FimDimensions, handle: string): CoreCanvas2D {
+  public createCoreCanvas2D(dimensions: FimDimensions, options: CoreCanvasOptions, handle: string): CoreCanvas2D {
     if (!this.engineOptions.disableOffscreenCanvas) {
-      return new CoreBrowserOffscreenCanvas2D(options, dimensions, handle, this.engineOptions);
+      return new CoreBrowserOffscreenCanvas2D(dimensions, options, handle, this.engineOptions);
     } else {
-      return new CoreBrowserDomCanvas2D(options, dimensions, handle, this.engineOptions);
+      return new CoreBrowserDomCanvas2D(dimensions, options, handle, this.engineOptions);
     }
   }
 
-  public createCoreCanvasWebGL(options: CoreCanvasOptions, dimensions: FimDimensions, handle: string): CoreCanvasWebGL {
+  public createCoreCanvasWebGL(dimensions: FimDimensions, options: CoreCanvasOptions, handle: string): CoreCanvasWebGL {
     if (!this.engineOptions.disableOffscreenCanvas) {
-      return new CoreBrowserOffscreenCanvasWebGL(options, dimensions, handle, this.engineOptions);
+      return new CoreBrowserOffscreenCanvasWebGL(dimensions, options, handle, this.engineOptions);
     } else {
-      return new CoreBrowserDomCanvasWebGL(options, dimensions, handle, this.engineOptions);
+      return new CoreBrowserDomCanvasWebGL(dimensions, options, handle, this.engineOptions);
     }
   }
 }

--- a/packages/fim-browser/src/engine/__tests__/BrowserEngineFim.browser.ts
+++ b/packages/fim-browser/src/engine/__tests__/BrowserEngineFim.browser.ts
@@ -3,12 +3,12 @@
 // See LICENSE in the project root for license information.
 
 import { BrowserEngineFim } from '../BrowserEngineFim';
-import { FimDimensions, FimReleaseResourcesFlags } from '@leosingleton/fim';
+import { FimReleaseResourcesFlags } from '@leosingleton/fim';
 
 describe('BrowserEngineFim', () => {
 
   it('Creates, releases, and disposes', () => {
-    const eng = new BrowserEngineFim(FimDimensions.fromWidthHeight(100, 100));
+    const eng = new BrowserEngineFim();
     eng.releaseResources(FimReleaseResourcesFlags.All);
     eng.dispose();
   });

--- a/packages/fim-browser/src/factory/FimBrowserFactory.ts
+++ b/packages/fim-browser/src/factory/FimBrowserFactory.ts
@@ -4,16 +4,14 @@
 
 import { FimBrowser } from '../api/FimBrowser';
 import { BrowserEngineFim } from '../engine/BrowserEngineFim';
-import { FimDimensions } from '@leosingleton/fim';
 
+/** Factory methods for instantiating the FIM library in web browsers */
 export namespace FimBrowserFactory {
   /**
    * Creates an instance of the FimBrowser interface
-   * @param maxImageDimensions Maximum dimensions of any image. If unspecified, defaults to the maximum image size
-   *    supported by the WebGL capabilities of the browser and GPU.
    * @param name An optional name specified when creating the object to help with debugging
    */
-  export function create(maxImageDimensions?: FimDimensions, name?: string): FimBrowser {
-    return new BrowserEngineFim(maxImageDimensions, name);
+  export function create(name?: string): FimBrowser {
+    return new BrowserEngineFim(name);
   }
 }

--- a/packages/fim-common-tests/src/api/Backup.ts
+++ b/packages/fim-common-tests/src/api/Backup.ts
@@ -4,19 +4,18 @@
 
 import { ImageInternals } from '../common/ImageInternals';
 import { TestImages } from '../common/TestImages';
-import { TestSizes } from '../common/TestSizes';
 import { usingAsync } from '@leosingleton/commonlibs';
-import { Fim, FimDimensions, FimOpInvert } from '@leosingleton/fim';
+import { Fim, FimOpInvert } from '@leosingleton/fim';
 
 /** FIM test cases around backing up WebGL textures to canvases */
 export function fimTestSuiteBackup(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FIM Backup - ${description}`, () => {
 
     it('Backs up with explicit calls to backupAsync()', async () => {
-      await usingAsync(factory(TestSizes.smallSquare), async fim => {
+      await usingAsync(factory(), async fim => {
         const invert = new FimOpInvert(fim);
 
         // Load an image
@@ -41,7 +40,7 @@ export function fimTestSuiteBackup(
     });
 
     it('Backs up automatically with imageOptions.autoBackup', async () => {
-      await usingAsync(factory(TestSizes.smallSquare), async fim => {
+      await usingAsync(factory(), async fim => {
         const invert = new FimOpInvert(fim);
 
         // Load an image and enable auto-backup

--- a/packages/fim-common-tests/src/api/Canvas.ts
+++ b/packages/fim-common-tests/src/api/Canvas.ts
@@ -8,17 +8,17 @@ import { TestColors } from '../common/TestColors';
 import { TestImages } from '../common/TestImages';
 import { TestSizes } from '../common/TestSizes';
 import { usingAsync } from '@leosingleton/commonlibs';
-import { Fim, FimDimensions, FimRect, FimError, FimOpGaussianBlur } from '@leosingleton/fim';
+import { Fim, FimRect, FimError, FimOpGaussianBlur } from '@leosingleton/fim';
 
 /** FIM test cases around canvas manipulation */
 export function fimTestSuiteCanvas(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FIM Canvas - ${description}`, () => {
 
     it('Supports fillSolid() and getPixel()', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const image = fim.createImage(TestSizes.smallWide);
         await image.fillSolidAsync(TestColors.red);
         expect(await image.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);
@@ -26,7 +26,7 @@ export function fimTestSuiteCanvas(
     });
 
     it('Supports loading pixels from array data', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const image = fim.createImage(TestSizes.smallWide);
         const pixelData = TestImages.solidPixelData(TestSizes.smallWide, TestColors.green);
         await image.loadPixelDataAsync(pixelData);
@@ -35,7 +35,7 @@ export function fimTestSuiteCanvas(
     });
 
     it('Supports loading pixels from array data with rescale', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const image = fim.createImage(TestSizes.smallWide);
         const pixelData = TestImages.solidPixelData(TestSizes.mediumTall, TestColors.blue);
         await image.loadPixelDataAsync(pixelData, TestSizes.mediumTall);
@@ -44,7 +44,7 @@ export function fimTestSuiteCanvas(
     });
 
     it('Supports loading pixels from array data (ImageBitmap disabled)', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         fim.engineOptions.disableImageBitmap = true;
         const image = fim.createImage(TestSizes.smallWide);
         const pixelData = TestImages.solidPixelData(TestSizes.smallWide, TestColors.green);
@@ -54,7 +54,7 @@ export function fimTestSuiteCanvas(
     });
 
     it('Supports loading pixels from array data with rescale (ImageBitmap disabled)', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         fim.engineOptions.disableImageBitmap = true;
         const image = fim.createImage(TestSizes.smallWide);
         const pixelData = TestImages.solidPixelData(TestSizes.mediumTall, TestColors.blue);
@@ -64,7 +64,7 @@ export function fimTestSuiteCanvas(
     });
 
     it('Copies from one image to another', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const image1 = fim.createImage(TestSizes.smallWide);
         const pixelData = TestImages.solidPixelData(TestSizes.smallWide, TestColors.red);
         await image1.loadPixelDataAsync(pixelData);
@@ -76,7 +76,7 @@ export function fimTestSuiteCanvas(
     });
 
     it('Copies from a solid fill to an image', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const image1 = fim.createImage(TestSizes.smallWide);
         await image1.fillSolidAsync(TestColors.red);
 
@@ -87,7 +87,7 @@ export function fimTestSuiteCanvas(
     });
 
     it('Copies with crop and rescale', async () => {
-      await usingAsync(factory(TestSizes.mediumTall), async fim => {
+      await usingAsync(factory(), async fim => {
         const png = TestImages.fourSquaresPng();
         const image1 = await fim.createImageFromPngAsync(png);
         const image2 = fim.createImage(TestSizes.mediumTall);
@@ -117,7 +117,7 @@ export function fimTestSuiteCanvas(
     });
 
     it('copyFrom() doesn\'t allow an uninitialized source image', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const image1 = fim.createImage(TestSizes.smallWide);
         const image2 = fim.createImage(TestSizes.smallWide);
         (await expectErrorAsync(image1.copyFromAsync(image2))).toBeInstanceOf(FimError);
@@ -125,7 +125,7 @@ export function fimTestSuiteCanvas(
     });
 
     it('copyFrom() doesn\'t allow copying itself', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const image = fim.createImage(TestSizes.smallWide);
         await image.fillSolidAsync(TestColors.red);
         (await expectErrorAsync(image.copyFromAsync(image))).toBeInstanceOf(FimError);
@@ -133,8 +133,8 @@ export function fimTestSuiteCanvas(
     });
 
     it('copyFrom() doesn\'t allow copying from another FIM instance', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim1 => {
-        await usingAsync(factory(TestSizes.smallWide), async fim2 => {
+      await usingAsync(factory(), async fim1 => {
+        await usingAsync(factory(), async fim2 => {
           const image1 = fim1.createImage(TestSizes.smallWide);
           const image2 = fim2.createImage(TestSizes.smallWide);
           await image2.fillSolidAsync(TestColors.red);
@@ -144,7 +144,7 @@ export function fimTestSuiteCanvas(
     });
 
     it('Exports to raw pixel data', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         // Create a solid red image
         const image = fim.createImage(TestSizes.smallWide);
         await image.fillSolidAsync(TestColors.red);
@@ -159,7 +159,7 @@ export function fimTestSuiteCanvas(
     });
 
     it('Supports debug mode, including tracing and warnings', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const blur = new FimOpGaussianBlur(fim);
 
         fim.engineOptions.debugMode = true;
@@ -183,7 +183,7 @@ export function fimTestSuiteCanvas(
     });
 
     it('Enforces memory limits', async () => {
-      await usingAsync(factory(TestSizes.largeWide), async fim => {
+      await usingAsync(factory(), async fim => {
         // 128 * 128 * 4 is just enough memory for the four squares test PNG
         fim.engineOptions.maxCanvasMemory = 128 * 128 * 4 + 10;
 

--- a/packages/fim-common-tests/src/api/Canvas.ts
+++ b/packages/fim-common-tests/src/api/Canvas.ts
@@ -160,6 +160,7 @@ export function fimTestSuiteCanvas(
 
     it('Supports debug mode, including tracing and warnings', async () => {
       await usingAsync(factory(), async fim => {
+        fim.engineOptions.maxImageDimensions = TestSizes.smallWide;
         const blur = new FimOpGaussianBlur(fim);
 
         fim.engineOptions.debugMode = true;

--- a/packages/fim-common-tests/src/api/Canvas.ts
+++ b/packages/fim-common-tests/src/api/Canvas.ts
@@ -167,7 +167,7 @@ export function fimTestSuiteCanvas(
         fim.engineOptions.showWarnings = true;
 
         // Create an image larger than the parent FIM instance to generate a warning
-        const image = fim.createImage({}, TestSizes.mediumTall);
+        const image = fim.createImage(TestSizes.mediumTall);
         await image.fillSolidAsync(TestColors.red);
 
         // Load a PNG image to generate some tracing

--- a/packages/fim-common-tests/src/api/Canvas.ts
+++ b/packages/fim-common-tests/src/api/Canvas.ts
@@ -19,7 +19,7 @@ export function fimTestSuiteCanvas(
 
     it('Supports fillSolid() and getPixel()', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         await image.fillSolidAsync(TestColors.red);
         expect(await image.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);
       });
@@ -27,7 +27,7 @@ export function fimTestSuiteCanvas(
 
     it('Supports loading pixels from array data', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         const pixelData = TestImages.solidPixelData(TestSizes.smallWide, TestColors.green);
         await image.loadPixelDataAsync(pixelData);
         expect(await image.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.green);
@@ -36,7 +36,7 @@ export function fimTestSuiteCanvas(
 
     it('Supports loading pixels from array data with rescale', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         const pixelData = TestImages.solidPixelData(TestSizes.mediumTall, TestColors.blue);
         await image.loadPixelDataAsync(pixelData, TestSizes.mediumTall);
         expect(await image.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.blue);
@@ -46,7 +46,7 @@ export function fimTestSuiteCanvas(
     it('Supports loading pixels from array data (ImageBitmap disabled)', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         fim.engineOptions.disableImageBitmap = true;
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         const pixelData = TestImages.solidPixelData(TestSizes.smallWide, TestColors.green);
         await image.loadPixelDataAsync(pixelData);
         expect(await image.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.green);
@@ -56,7 +56,7 @@ export function fimTestSuiteCanvas(
     it('Supports loading pixels from array data with rescale (ImageBitmap disabled)', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         fim.engineOptions.disableImageBitmap = true;
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         const pixelData = TestImages.solidPixelData(TestSizes.mediumTall, TestColors.blue);
         await image.loadPixelDataAsync(pixelData, TestSizes.mediumTall);
         expect(await image.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.blue);
@@ -65,11 +65,11 @@ export function fimTestSuiteCanvas(
 
     it('Copies from one image to another', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
-        const image1 = fim.createImage();
+        const image1 = fim.createImage(TestSizes.smallWide);
         const pixelData = TestImages.solidPixelData(TestSizes.smallWide, TestColors.red);
         await image1.loadPixelDataAsync(pixelData);
 
-        const image2 = fim.createImage();
+        const image2 = fim.createImage(TestSizes.smallWide);
         await image2.copyFromAsync(image1);
         expect(await image2.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);
       });
@@ -77,10 +77,10 @@ export function fimTestSuiteCanvas(
 
     it('Copies from a solid fill to an image', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
-        const image1 = fim.createImage();
+        const image1 = fim.createImage(TestSizes.smallWide);
         await image1.fillSolidAsync(TestColors.red);
 
-        const image2 = fim.createImage();
+        const image2 = fim.createImage(TestSizes.smallWide);
         await image2.copyFromAsync(image1);
         expect(await image2.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);
       });
@@ -90,7 +90,7 @@ export function fimTestSuiteCanvas(
       await usingAsync(factory(TestSizes.mediumTall), async fim => {
         const png = TestImages.fourSquaresPng();
         const image1 = await fim.createImageFromPngAsync(png);
-        const image2 = fim.createImage();
+        const image2 = fim.createImage(TestSizes.mediumTall);
 
         // Scale image1 (128x128) to medium size (480x640)
         await image2.copyFromAsync(image1);
@@ -118,15 +118,15 @@ export function fimTestSuiteCanvas(
 
     it('copyFrom() doesn\'t allow an uninitialized source image', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
-        const image1 = fim.createImage();
-        const image2 = fim.createImage();
+        const image1 = fim.createImage(TestSizes.smallWide);
+        const image2 = fim.createImage(TestSizes.smallWide);
         (await expectErrorAsync(image1.copyFromAsync(image2))).toBeInstanceOf(FimError);
       });
     });
 
     it('copyFrom() doesn\'t allow copying itself', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         await image.fillSolidAsync(TestColors.red);
         (await expectErrorAsync(image.copyFromAsync(image))).toBeInstanceOf(FimError);
       });
@@ -135,8 +135,8 @@ export function fimTestSuiteCanvas(
     it('copyFrom() doesn\'t allow copying from another FIM instance', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim1 => {
         await usingAsync(factory(TestSizes.smallWide), async fim2 => {
-          const image1 = fim1.createImage();
-          const image2 = fim2.createImage();
+          const image1 = fim1.createImage(TestSizes.smallWide);
+          const image2 = fim2.createImage(TestSizes.smallWide);
           await image2.fillSolidAsync(TestColors.red);
           (await expectErrorAsync(image1.copyFromAsync(image2))).toBeInstanceOf(FimError);
         });
@@ -146,7 +146,7 @@ export function fimTestSuiteCanvas(
     it('Exports to raw pixel data', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         // Create a solid red image
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         await image.fillSolidAsync(TestColors.red);
 
         // Export to RGBA pixel data
@@ -194,7 +194,7 @@ export function fimTestSuiteCanvas(
 
         // Allocate a large canvas and copy the test pattern to it. This will throw an OutOfMemory FimError as it
         // exceeds the limit set in engineOptions.
-        const largeImage = fim.createImage();
+        const largeImage = fim.createImage(TestSizes.largeWide);
         (await expectErrorAsync(largeImage.copyFromAsync(smallImage))).toBeInstanceOf(FimError);
       });
     });

--- a/packages/fim-common-tests/src/api/CreateDispose.ts
+++ b/packages/fim-common-tests/src/api/CreateDispose.ts
@@ -6,17 +6,17 @@ import { fillConstShader, fillUniformShader } from '../common/Shaders';
 import { TestColors } from '../common/TestColors';
 import { TestSizes } from '../common/TestSizes';
 import { using, usingAsync } from '@leosingleton/commonlibs';
-import { Fim, FimDimensions, FimImage, FimShader } from '@leosingleton/fim';
+import { Fim, FimImage, FimShader } from '@leosingleton/fim';
 
 /** Create/dispose tests for FIM */
 export function fimTestSuiteCreateDispose(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FIM Create/Dispose - ${description}`, () => {
 
     it('Creates and disposes', () => {
-      const fim = factory(TestSizes.smallWide);
+      const fim = factory();
       fim.dispose();
 
       // Double-dispose throws an exception
@@ -24,7 +24,7 @@ export function fimTestSuiteCreateDispose(
     });
 
     it('Handles multiple releaseAllResources() calls', () => {
-      using(factory(TestSizes.smallWide), fim => {
+      using(factory(), fim => {
         fim.releaseAllResources();
         fim.releaseAllResources();
         fim.releaseAllResources();
@@ -32,7 +32,7 @@ export function fimTestSuiteCreateDispose(
     });
 
     it('Creates and disposes images', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const img1 = fim.createImage(TestSizes.smallWide);
         await img1.fillSolidAsync(TestColors.red);
         img1.dispose();
@@ -43,7 +43,7 @@ export function fimTestSuiteCreateDispose(
     });
 
     it('Creates and disposes shaders', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const shader1 = fim.createGLShader(fillConstShader);
         shader1.dispose();
 
@@ -56,7 +56,7 @@ export function fimTestSuiteCreateDispose(
       let shader: FimShader;
       let image: FimImage;
 
-      using(factory(TestSizes.smallWide), fim => {
+      using(factory(), fim => {
         shader = fim.createGLShader(fillConstShader);
         image = fim.createImage(TestSizes.smallWide);
       });

--- a/packages/fim-common-tests/src/api/CreateDispose.ts
+++ b/packages/fim-common-tests/src/api/CreateDispose.ts
@@ -33,11 +33,11 @@ export function fimTestSuiteCreateDispose(
 
     it('Creates and disposes images', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
-        const img1 = fim.createImage();
+        const img1 = fim.createImage(TestSizes.smallWide);
         await img1.fillSolidAsync(TestColors.red);
         img1.dispose();
 
-        const img2 = fim.createImage();
+        const img2 = fim.createImage(TestSizes.smallWide);
         img2.dispose();
       });
     });
@@ -58,7 +58,7 @@ export function fimTestSuiteCreateDispose(
 
       using(factory(TestSizes.smallWide), fim => {
         shader = fim.createGLShader(fillConstShader);
-        image = fim.createImage();
+        image = fim.createImage(TestSizes.smallWide);
       });
 
       // The shader and image are automatically disposed by the parent FIM instance. Calling dispose() again on these

--- a/packages/fim-common-tests/src/api/Downscaled.ts
+++ b/packages/fim-common-tests/src/api/Downscaled.ts
@@ -8,7 +8,7 @@ import { TestColors } from '../common/TestColors';
 import { TestImages } from '../common/TestImages';
 import { TestSizes } from '../common/TestSizes';
 import { usingAsync } from '@leosingleton/commonlibs';
-import { Fim, FimDimensions, FimOpInvert, FimRect } from '@leosingleton/fim';
+import { Fim, FimOpInvert, FimRect } from '@leosingleton/fim';
 
 /**
  * FIM test cases around handling downscaled images
@@ -19,12 +19,12 @@ import { Fim, FimDimensions, FimOpInvert, FimRect } from '@leosingleton/fim';
  */
 export function fimTestSuiteDownscaled(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FIM Downscaled - ${description}`, () => {
 
     it('Preserves input dimensions when copying', async () => {
-      await usingAsync(factory(TestSizes.mediumSquare), async fim => {
+      await usingAsync(factory(), async fim => {
         // Create a small image
         const smallImage = fim.createImage(TestSizes.smallSquare);
         await smallImage.loadFromPngAsync(TestImages.fourSquaresPng());
@@ -43,7 +43,7 @@ export function fimTestSuiteDownscaled(
     });
 
     it('Preserves input dimensions when copying with srcCoords', async () => {
-      await usingAsync(factory(TestSizes.mediumSquare), async fim => {
+      await usingAsync(factory(), async fim => {
         // Create a small test image
         const smallImage = await fim.createImageFromPngAsync(TestImages.fourSquaresPng());
 
@@ -65,7 +65,7 @@ export function fimTestSuiteDownscaled(
     });
 
     it('Preserves dimensions when loading from a smaller image', async () => {
-      await usingAsync(factory(TestSizes.mediumSquare), async fim => {
+      await usingAsync(factory(), async fim => {
         // Create a medium 640x640 image
         const image = fim.createImage(TestSizes.mediumSquare);
 
@@ -82,7 +82,8 @@ export function fimTestSuiteDownscaled(
     });
 
     it('Preserves dimensions when transfering to a WebGL texture and back', async () => {
-      await usingAsync(factory(TestSizes.mediumSquare), async fim => {
+      await usingAsync(factory(), async fim => {
+        fim.engineOptions.maxImageDimensions = TestSizes.mediumSquare;
         const invert = new FimOpInvert(fim);
 
         // Create a medium 640x640 image
@@ -129,7 +130,9 @@ export function fimTestSuiteDownscaled(
     });
 
     it('Upscales dimensions when copying and preserveDownscaledDimensions=false', async () => {
-      await usingAsync(factory(TestSizes.mediumSquare), async fim => {
+      await usingAsync(factory(), async fim => {
+        fim.engineOptions.maxImageDimensions = TestSizes.mediumSquare;
+
         // Create a small image
         const smallImage = fim.createImage(TestSizes.smallSquare);
         await smallImage.loadFromPngAsync(TestImages.fourSquaresPng());
@@ -148,7 +151,9 @@ export function fimTestSuiteDownscaled(
     });
 
     it('Upscales dimensions when loading from a smaller image and preserveDownscaledDimensions=false', async () => {
-      await usingAsync(factory(TestSizes.mediumSquare), async fim => {
+      await usingAsync(factory(), async fim => {
+        fim.engineOptions.maxImageDimensions = TestSizes.mediumSquare;
+
         // Create a medium 640x640 image
         const image = fim.createImage(TestSizes.mediumSquare, { preserveDownscaledDimensions: false });
 
@@ -165,7 +170,7 @@ export function fimTestSuiteDownscaled(
     });
 
     it('Upscales dimensions when glDownscale < downscale and preserveDownscaledDimensions=false', async () => {
-      await usingAsync(factory(TestSizes.mediumSquare), async fim => {
+      await usingAsync(factory(), async fim => {
         const invert = new FimOpInvert(fim);
 
         // Create a small test image

--- a/packages/fim-common-tests/src/api/Downscaled.ts
+++ b/packages/fim-common-tests/src/api/Downscaled.ts
@@ -26,7 +26,7 @@ export function fimTestSuiteDownscaled(
     it('Preserves input dimensions when copying', async () => {
       await usingAsync(factory(TestSizes.mediumSquare), async fim => {
         // Create a small image
-        const smallImage = fim.createImage({}, TestSizes.smallSquare);
+        const smallImage = fim.createImage(TestSizes.smallSquare);
         await smallImage.loadFromPngAsync(TestImages.fourSquaresPng());
 
         // Copy the small image to a medium image
@@ -131,11 +131,11 @@ export function fimTestSuiteDownscaled(
     it('Upscales dimensions when copying and preserveDownscaledDimensions=false', async () => {
       await usingAsync(factory(TestSizes.mediumSquare), async fim => {
         // Create a small image
-        const smallImage = fim.createImage({}, TestSizes.smallSquare);
+        const smallImage = fim.createImage(TestSizes.smallSquare);
         await smallImage.loadFromPngAsync(TestImages.fourSquaresPng());
 
         // Copy the small image to a medium image
-        const mediumImage = fim.createImage({ preserveDownscaledDimensions: false });
+        const mediumImage = fim.createImage(TestSizes.mediumSquare, { preserveDownscaledDimensions: false });
         await mediumImage.copyFromAsync(smallImage);
 
         // The image contents should be upscaled to the destination dimensions
@@ -150,7 +150,7 @@ export function fimTestSuiteDownscaled(
     it('Upscales dimensions when loading from a smaller image and preserveDownscaledDimensions=false', async () => {
       await usingAsync(factory(TestSizes.mediumSquare), async fim => {
         // Create a medium 640x640 image
-        const image = fim.createImage({ preserveDownscaledDimensions: false });
+        const image = fim.createImage(TestSizes.mediumSquare, { preserveDownscaledDimensions: false });
 
         // Load a 128x128 PNG onto the 640x640 image with "rescale"
         await image.loadFromPngAsync(TestImages.fourSquaresPng(), true);
@@ -172,8 +172,8 @@ export function fimTestSuiteDownscaled(
         const inputImage = await fim.createImageFromPngAsync(TestImages.fourSquaresPng());
 
         // Create a small destination image with glDownscale = 0.5
-        const outputImage = fim.createImage({ glDownscale: 0.5, preserveDownscaledDimensions: false },
-          TestSizes.smallSquare);
+        const outputImage = fim.createImage(TestSizes.smallSquare,
+          { glDownscale: 0.5, preserveDownscaledDimensions: false });
 
         // Populate the destination image with a WebGL shader
         await outputImage.executeAsync(invert.$(inputImage));

--- a/packages/fim-common-tests/src/api/Downscaled.ts
+++ b/packages/fim-common-tests/src/api/Downscaled.ts
@@ -30,7 +30,7 @@ export function fimTestSuiteDownscaled(
         await smallImage.loadFromPngAsync(TestImages.fourSquaresPng());
 
         // Copy the small image to a medium image
-        const mediumImage = fim.createImage();
+        const mediumImage = fim.createImage(TestSizes.mediumSquare);
         await mediumImage.copyFromAsync(smallImage);
 
         // The memory backing the medium image should actually be the same size as the small one
@@ -48,7 +48,7 @@ export function fimTestSuiteDownscaled(
         const smallImage = await fim.createImageFromPngAsync(TestImages.fourSquaresPng());
 
         // Copy the top-right corner of the small image to a medium image
-        const mediumImage = fim.createImage();
+        const mediumImage = fim.createImage(TestSizes.mediumSquare);
         const srcCoords = FimRect.fromXYWidthHeight(64, 0, 64, 64);
         await mediumImage.copyFromAsync(smallImage, srcCoords);
 
@@ -67,7 +67,7 @@ export function fimTestSuiteDownscaled(
     it('Preserves dimensions when loading from a smaller image', async () => {
       await usingAsync(factory(TestSizes.mediumSquare), async fim => {
         // Create a medium 640x640 image
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.mediumSquare);
 
         // Load a 128x128 PNG onto the 640x640 image with "rescale"
         await image.loadFromPngAsync(TestImages.fourSquaresPng(), true);
@@ -86,7 +86,7 @@ export function fimTestSuiteDownscaled(
         const invert = new FimOpInvert(fim);
 
         // Create a medium 640x640 image
-        const image1 = fim.createImage();
+        const image1 = fim.createImage(TestSizes.mediumSquare);
 
         // Load a 128x128 PNG onto the 640x640 image with "rescale"
         await image1.loadFromPngAsync(TestImages.fourSquaresPng(), true);
@@ -96,7 +96,7 @@ export function fimTestSuiteDownscaled(
         expect(ImageInternals.getCanvas(image1).dim).toEqual(TestSizes.smallSquare);
 
         // Perform an invert as a WebGL operation
-        const image2 = fim.createImage();
+        const image2 = fim.createImage(TestSizes.mediumSquare);
         await image2.executeAsync(invert.$(image1));
 
         // The input WebGL texture remained 128x128, but the output texture was the requested dimensions

--- a/packages/fim-common-tests/src/api/Downscaled.ts
+++ b/packages/fim-common-tests/src/api/Downscaled.ts
@@ -83,7 +83,6 @@ export function fimTestSuiteDownscaled(
 
     it('Preserves dimensions when transfering to a WebGL texture and back', async () => {
       await usingAsync(factory(), async fim => {
-        fim.engineOptions.maxImageDimensions = TestSizes.mediumSquare;
         const invert = new FimOpInvert(fim);
 
         // Create a medium 640x640 image
@@ -131,8 +130,6 @@ export function fimTestSuiteDownscaled(
 
     it('Upscales dimensions when copying and preserveDownscaledDimensions=false', async () => {
       await usingAsync(factory(), async fim => {
-        fim.engineOptions.maxImageDimensions = TestSizes.mediumSquare;
-
         // Create a small image
         const smallImage = fim.createImage(TestSizes.smallSquare);
         await smallImage.loadFromPngAsync(TestImages.fourSquaresPng());
@@ -152,8 +149,6 @@ export function fimTestSuiteDownscaled(
 
     it('Upscales dimensions when loading from a smaller image and preserveDownscaledDimensions=false', async () => {
       await usingAsync(factory(), async fim => {
-        fim.engineOptions.maxImageDimensions = TestSizes.mediumSquare;
-
         // Create a medium 640x640 image
         const image = fim.createImage(TestSizes.mediumSquare, { preserveDownscaledDimensions: false });
 

--- a/packages/fim-common-tests/src/api/Image.ts
+++ b/packages/fim-common-tests/src/api/Image.ts
@@ -4,18 +4,18 @@
 
 import { TestSizes } from '../common/TestSizes';
 import { using } from '@leosingleton/commonlibs';
-import { Fim, FimDimensions } from '@leosingleton/fim';
+import { Fim } from '@leosingleton/fim';
 import { defaultImageOptions } from '@leosingleton/fim/internals';
 
 /** Image tests for FIM */
 export function fimTestSuiteImage(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FIM Image - ${description}`, () => {
 
     it('Computes effective image options', () => {
-      using(factory(TestSizes.smallWide), fim => {
+      using(factory(), fim => {
         const image = fim.createImage(TestSizes.smallWide);
         const options = image.getEffectiveImageOptions();
         expect(options.allowOversized).toEqual(defaultImageOptions.allowOversized);

--- a/packages/fim-common-tests/src/api/Image.ts
+++ b/packages/fim-common-tests/src/api/Image.ts
@@ -16,7 +16,7 @@ export function fimTestSuiteImage(
 
     it('Computes effective image options', () => {
       using(factory(TestSizes.smallWide), fim => {
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         const options = image.getEffectiveImageOptions();
         expect(options.allowOversized).toEqual(defaultImageOptions.allowOversized);
         expect(options.autoBackup).toEqual(defaultImageOptions.autoBackup);

--- a/packages/fim-common-tests/src/api/Operation.ts
+++ b/packages/fim-common-tests/src/api/Operation.ts
@@ -57,7 +57,7 @@ export function fimTestSuiteOperation(
     it('Executes a simple mock operation', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const fillOp = new MockOpFillRed(fim);
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         await image.executeAsync(fillOp);
         expect(await image.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);
       });
@@ -66,7 +66,7 @@ export function fimTestSuiteOperation(
     it('Executes a child operation built on another operation', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const fillOp = new MockOpFillRedChild(fim);
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         await image.executeAsync(fillOp);
         expect(await image.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);
       });
@@ -75,7 +75,7 @@ export function fimTestSuiteOperation(
     it('Executes a grandchild operation built on a child operation', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const fillOp = new MockOpFillRedGrandchild(fim);
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         await image.executeAsync(fillOp);
         expect(await image.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);
       });

--- a/packages/fim-common-tests/src/api/Operation.ts
+++ b/packages/fim-common-tests/src/api/Operation.ts
@@ -5,7 +5,7 @@
 import { midpoint } from '../common/Globals';
 import { TestColors } from '../common/TestColors';
 import { TestSizes } from '../common/TestSizes';
-import { Fim, FimDimensions, FimImage, FimObject, FimOperation, FimRect } from '@leosingleton/fim';
+import { Fim, FimImage, FimObject, FimOperation, FimRect } from '@leosingleton/fim';
 import { usingAsync } from '@leosingleton/commonlibs';
 
 /** Mock operation for unit tests that performs a solid red fill. This is pretty useless, but good to test with. */
@@ -50,12 +50,12 @@ class MockOpFillRedGrandchild extends FimOperation {
 /** Unit tests for `FimOperation` */
 export function fimTestSuiteOperation(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FimOperation - ${description}`, () => {
 
     it('Executes a simple mock operation', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const fillOp = new MockOpFillRed(fim);
         const image = fim.createImage(TestSizes.smallWide);
         await image.executeAsync(fillOp);
@@ -64,7 +64,7 @@ export function fimTestSuiteOperation(
     });
 
     it('Executes a child operation built on another operation', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const fillOp = new MockOpFillRedChild(fim);
         const image = fim.createImage(TestSizes.smallWide);
         await image.executeAsync(fillOp);
@@ -73,7 +73,7 @@ export function fimTestSuiteOperation(
     });
 
     it('Executes a grandchild operation built on a child operation', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const fillOp = new MockOpFillRedGrandchild(fim);
         const image = fim.createImage(TestSizes.smallWide);
         await image.executeAsync(fillOp);

--- a/packages/fim-common-tests/src/api/Oversized.ts
+++ b/packages/fim-common-tests/src/api/Oversized.ts
@@ -20,12 +20,14 @@ import { Fim, FimBitsPerPixel, FimDimensions, FimOpInvert, FimOpUnsharpMask, Fim
  */
 export function fimTestSuiteOversized(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FIM Oversized - ${description}`, () => {
 
     it('Downscales images larger than parent FIM', () => {
-      using(factory(TestSizes.smallWide), fim => {
+      using(factory(), fim => {
+        fim.engineOptions.maxImageDimensions = TestSizes.smallWide;
+
         const image = fim.createImage(TestSizes.mediumTall);
         const eff = image.getEffectiveImageOptions();
 
@@ -36,7 +38,9 @@ export function fimTestSuiteOversized(
     });
 
     it('Supports allowOversized image option', () => {
-      using(factory(TestSizes.smallWide), fim => {
+      using(factory(), fim => {
+        fim.engineOptions.maxImageDimensions = TestSizes.smallSquare;
+
         const image = fim.createImage(TestSizes.mediumTall, { allowOversized: true });
         const eff = image.getEffectiveImageOptions();
 
@@ -47,7 +51,7 @@ export function fimTestSuiteOversized(
     });
 
     it('Supports custom downscale ratios', () => {
-      using(factory(TestSizes.mediumTall), fim => {
+      using(factory(), fim => {
         const image = fim.createImage(TestSizes.mediumTall, {
           downscale: 0.5,
           glDownscale: 0.05
@@ -61,7 +65,7 @@ export function fimTestSuiteOversized(
     });
 
     it('Import and export pixel data accepts original dimensions', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const image = fim.createImage(TestSizes.mediumTall);
 
         // renderAsync() uses the image's dimensions (medium)
@@ -79,7 +83,9 @@ export function fimTestSuiteOversized(
     });
 
     it('Import and export PNG accepts original dimensions', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
+        fim.engineOptions.maxImageDimensions = TestSizes.smallWide;
+
         // 128x128 PNG is larger than the 128x32 small FIM instance
         const png = TestImages.fourSquaresPng();
         const image = await fim.createImageFromPngAsync(png);
@@ -102,7 +108,9 @@ export function fimTestSuiteOversized(
     });
 
     it('Import and export JPEG accepts original dimensions', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
+        fim.engineOptions.maxImageDimensions = TestSizes.smallWide;
+
         // 128x128 JPEG is larger than the 128x32 small FIM instance
         const jpeg = TestImages.fourSquaresJpeg();
         const image = await fim.createImageFromJpegAsync(jpeg);
@@ -127,7 +135,7 @@ export function fimTestSuiteOversized(
     it('Copies with crop and rescale', async () => {
       // This is copy-and-paste code from the unit test in Canvas.ts, except this time we run it with the parent FIM
       // instance set to small, so all images get transparently downscaled.
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const png = TestImages.fourSquaresPng();
         const image1 = await fim.createImageFromPngAsync(png);
         const image2 = fim.createImage(TestSizes.mediumTall);
@@ -157,7 +165,9 @@ export function fimTestSuiteOversized(
     });
 
     it('Calculates correct ratios for CoreCanvas2D', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
+        fim.engineOptions.maxImageDimensions = TestSizes.smallWide;
+
         // Load a 128x128 PNG with a FIM instance of 128x32
         const png = TestImages.fourSquaresPng();
         const image = await fim.createImageFromPngAsync(png);
@@ -170,7 +180,8 @@ export function fimTestSuiteOversized(
     });
 
     it('Calculates correct ratio for CoreTexture', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
+        fim.engineOptions.maxImageDimensions = TestSizes.smallWide;
         const invert = new FimOpInvert(fim);
 
         // Load a 128x128 PNG with a FIM instance of 128x32
@@ -188,7 +199,7 @@ export function fimTestSuiteOversized(
     });
 
     it('Handles WebGL with downscale', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         // Create FIM resources
         const png = TestImages.fourSquaresPng();
         const inputImage = await fim.createImageFromPngAsync(png, { bpp: FimBitsPerPixel.BPP8, glReadOnly: true });

--- a/packages/fim-common-tests/src/api/Oversized.ts
+++ b/packages/fim-common-tests/src/api/Oversized.ts
@@ -26,7 +26,7 @@ export function fimTestSuiteOversized(
 
     it('Downscales images larger than parent FIM', () => {
       using(factory(TestSizes.smallWide), fim => {
-        const image = fim.createImage({}, TestSizes.mediumTall);
+        const image = fim.createImage(TestSizes.mediumTall);
         const eff = image.getEffectiveImageOptions();
 
         // Y-axis to get downscaled from 640 to 32 pixels
@@ -37,7 +37,7 @@ export function fimTestSuiteOversized(
 
     it('Supports allowOversized image option', () => {
       using(factory(TestSizes.smallWide), fim => {
-        const image = fim.createImage({ allowOversized: true }, TestSizes.mediumTall);
+        const image = fim.createImage(TestSizes.mediumTall, { allowOversized: true });
         const eff = image.getEffectiveImageOptions();
 
         // No downscale occurs
@@ -48,10 +48,10 @@ export function fimTestSuiteOversized(
 
     it('Supports custom downscale ratios', () => {
       using(factory(TestSizes.mediumTall), fim => {
-        const image = fim.createImage({
+        const image = fim.createImage(TestSizes.mediumTall, {
           downscale: 0.5,
           glDownscale: 0.05
-        }, TestSizes.mediumTall);
+        });
         const eff = image.getEffectiveImageOptions();
 
         // Downscale matches image options as FIM and image have same dimensions
@@ -62,7 +62,7 @@ export function fimTestSuiteOversized(
 
     it('Import and export pixel data accepts original dimensions', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
-        const image = fim.createImage({}, TestSizes.mediumTall);
+        const image = fim.createImage(TestSizes.mediumTall);
 
         // renderAsync() uses the image's dimensions (medium)
         await TestPatterns.renderAsync(image, TestPatterns.horizontalGradient);
@@ -130,7 +130,7 @@ export function fimTestSuiteOversized(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const png = TestImages.fourSquaresPng();
         const image1 = await fim.createImageFromPngAsync(png);
-        const image2 = fim.createImage({}, TestSizes.mediumTall);
+        const image2 = fim.createImage(TestSizes.mediumTall);
 
         // Scale image1 (128x128) to medium size (480x640)
         await image2.copyFromAsync(image1);
@@ -192,7 +192,7 @@ export function fimTestSuiteOversized(
         // Create FIM resources
         const png = TestImages.fourSquaresPng();
         const inputImage = await fim.createImageFromPngAsync(png, { bpp: FimBitsPerPixel.BPP8, glReadOnly: true });
-        const outputImage = fim.createImage({}, TestSizes.smallSquare);
+        const outputImage = fim.createImage(TestSizes.smallSquare);
         const unsharpMask = new FimOpUnsharpMask(fim, true);
 
         // Run the WebGL operation

--- a/packages/fim-common-tests/src/api/PngJpeg.ts
+++ b/packages/fim-common-tests/src/api/PngJpeg.ts
@@ -17,7 +17,7 @@ export function fimTestSuitePngJpeg(
 
     it('Imports from PNG', async () => {
       await usingAsync(factory(TestSizes.smallSquare), async fim => {
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallSquare);
         const png = TestImages.fourSquaresPng();
         await image.loadFromPngAsync(png);
 
@@ -27,7 +27,7 @@ export function fimTestSuitePngJpeg(
 
     it('Imports from JPEG', async () => {
       await usingAsync(factory(TestSizes.smallSquare), async fim => {
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallSquare);
         const jpeg = TestImages.fourSquaresJpeg();
         await image.loadFromJpegAsync(jpeg);
 
@@ -37,7 +37,7 @@ export function fimTestSuitePngJpeg(
 
     it('Imports from PNG with rescale', async () => {
       await usingAsync(factory(TestSizes.mediumTall), async fim => {
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.mediumTall);
         const png = TestImages.fourSquaresPng();
         await image.loadFromPngAsync(png, true);
 
@@ -47,7 +47,7 @@ export function fimTestSuitePngJpeg(
 
     it('Imports from JPEG with rescale', async () => {
       await usingAsync(factory(TestSizes.mediumTall), async fim => {
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.mediumTall);
         const jpeg = TestImages.fourSquaresJpeg();
         await image.loadFromJpegAsync(jpeg, true);
 
@@ -57,7 +57,7 @@ export function fimTestSuitePngJpeg(
 
     it('Exports to PNG', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         await image.fillSolidAsync(TestColors.red);
         const png = await image.exportToPngAsync();
 
@@ -71,7 +71,7 @@ export function fimTestSuitePngJpeg(
 
     it('Exports to JPEG', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         await image.fillSolidAsync(TestColors.red);
         const jpeg = await image.exportToJpegAsync();
 

--- a/packages/fim-common-tests/src/api/PngJpeg.ts
+++ b/packages/fim-common-tests/src/api/PngJpeg.ts
@@ -6,17 +6,17 @@ import { TestColors } from '../common/TestColors';
 import { TestImages } from '../common/TestImages';
 import { TestSizes } from '../common/TestSizes';
 import { usingAsync } from '@leosingleton/commonlibs';
-import { Fim, FimDimensions } from '@leosingleton/fim';
+import { Fim } from '@leosingleton/fim';
 
 /** FIM test cases around PNG and JPEG encoding/decoding */
 export function fimTestSuitePngJpeg(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FIM PNG/JPEG - ${description}`, () => {
 
     it('Imports from PNG', async () => {
-      await usingAsync(factory(TestSizes.smallSquare), async fim => {
+      await usingAsync(factory(), async fim => {
         const image = fim.createImage(TestSizes.smallSquare);
         const png = TestImages.fourSquaresPng();
         await image.loadFromPngAsync(png);
@@ -26,7 +26,7 @@ export function fimTestSuitePngJpeg(
     });
 
     it('Imports from JPEG', async () => {
-      await usingAsync(factory(TestSizes.smallSquare), async fim => {
+      await usingAsync(factory(), async fim => {
         const image = fim.createImage(TestSizes.smallSquare);
         const jpeg = TestImages.fourSquaresJpeg();
         await image.loadFromJpegAsync(jpeg);
@@ -36,7 +36,7 @@ export function fimTestSuitePngJpeg(
     });
 
     it('Imports from PNG with rescale', async () => {
-      await usingAsync(factory(TestSizes.mediumTall), async fim => {
+      await usingAsync(factory(), async fim => {
         const image = fim.createImage(TestSizes.mediumTall);
         const png = TestImages.fourSquaresPng();
         await image.loadFromPngAsync(png, true);
@@ -46,7 +46,7 @@ export function fimTestSuitePngJpeg(
     });
 
     it('Imports from JPEG with rescale', async () => {
-      await usingAsync(factory(TestSizes.mediumTall), async fim => {
+      await usingAsync(factory(), async fim => {
         const image = fim.createImage(TestSizes.mediumTall);
         const jpeg = TestImages.fourSquaresJpeg();
         await image.loadFromJpegAsync(jpeg, true);
@@ -56,7 +56,7 @@ export function fimTestSuitePngJpeg(
     });
 
     it('Exports to PNG', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const image = fim.createImage(TestSizes.smallWide);
         await image.fillSolidAsync(TestColors.red);
         const png = await image.exportToPngAsync();
@@ -70,7 +70,7 @@ export function fimTestSuitePngJpeg(
     });
 
     it('Exports to JPEG', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const image = fim.createImage(TestSizes.smallWide);
         await image.fillSolidAsync(TestColors.red);
         const jpeg = await image.exportToJpegAsync();
@@ -83,7 +83,7 @@ export function fimTestSuitePngJpeg(
     });
 
     it('Creates from PNG', async () => {
-      await usingAsync(factory(TestSizes.mediumTall), async fim => {
+      await usingAsync(factory(), async fim => {
         const png = TestImages.fourSquaresPng();
         const image = await fim.createImageFromPngAsync(png);
 
@@ -93,7 +93,7 @@ export function fimTestSuitePngJpeg(
     });
 
     it('Creates from JPEG', async () => {
-      await usingAsync(factory(TestSizes.mediumTall), async fim => {
+      await usingAsync(factory(), async fim => {
         const jpeg = TestImages.fourSquaresJpeg();
         const image = await fim.createImageFromJpegAsync(jpeg);
 

--- a/packages/fim-common-tests/src/api/ResourceTracker.ts
+++ b/packages/fim-common-tests/src/api/ResourceTracker.ts
@@ -17,7 +17,7 @@ export function fimTestSuiteResourceTracker(
     it('Tracks canvas resources', async () => {
       const fim = factory(TestSizes.smallSquare);
       await usingAsync(fim, async fim => {
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallSquare);
         const png = TestImages.fourSquaresPng();
         await image.loadFromPngAsync(png);
 

--- a/packages/fim-common-tests/src/api/ResourceTracker.ts
+++ b/packages/fim-common-tests/src/api/ResourceTracker.ts
@@ -5,17 +5,17 @@
 import { TestImages } from '../common/TestImages';
 import { TestSizes } from '../common/TestSizes';
 import { usingAsync } from '@leosingleton/commonlibs';
-import { Fim, FimDimensions } from '@leosingleton/fim';
+import { Fim } from '@leosingleton/fim';
 
 /** FIM test cases around resource tracking */
 export function fimTestSuiteResourceTracker(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FIM Resource Tracker - ${description}`, () => {
 
     it('Tracks canvas resources', async () => {
-      const fim = factory(TestSizes.smallSquare);
+      const fim = factory();
       await usingAsync(fim, async fim => {
         const image = fim.createImage(TestSizes.smallSquare);
         const png = TestImages.fourSquaresPng();

--- a/packages/fim-common-tests/src/api/WebGL.ts
+++ b/packages/fim-common-tests/src/api/WebGL.ts
@@ -10,17 +10,17 @@ import { TestImages } from '../common/TestImages';
 import { TestPatterns } from '../common/TestPatterns';
 import { TestSizes } from '../common/TestSizes';
 import { using, usingAsync } from '@leosingleton/commonlibs';
-import { Fim, FimColor, FimDimensions, FimError, FimTextureSampling } from '@leosingleton/fim';
+import { Fim, FimColor, FimError, FimTextureSampling } from '@leosingleton/fim';
 
 /** WebGL tests for FIM */
 export function fimTestSuiteWebGL(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FIM WebGL - ${description}`, () => {
 
     it('Detects WebGL capabilities', () => {
-      using(factory(TestSizes.smallWide), fim => {
+      using(factory(), fim => {
         const caps = fim.capabilities;
         expect(caps.glVersion.length).toBeGreaterThan(0);
         expect(caps.glShadingLanguageVersion.length).toBeGreaterThan(0);
@@ -37,7 +37,7 @@ export function fimTestSuiteWebGL(
     });
 
     it('Executes a simple fill shader with a constant', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillConstShader);
         const image = fim.createImage(TestSizes.smallWide);
@@ -55,7 +55,7 @@ export function fimTestSuiteWebGL(
     });
 
     it('Executes a simple fill shader with a uniform', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillUniformShader);
         const image = fim.createImage(TestSizes.smallWide);
@@ -72,7 +72,7 @@ export function fimTestSuiteWebGL(
     });
 
     it('Executes a shader with an image parameter', async () => {
-      await usingAsync(factory(TestSizes.smallSquare), async fim => {
+      await usingAsync(factory(), async fim => {
         // Load the four squares sample on to an image
         const srcImage = fim.createImage(TestSizes.smallSquare);
         await srcImage.loadFromPngAsync(TestImages.fourSquaresPng());
@@ -91,7 +91,7 @@ export function fimTestSuiteWebGL(
     });
 
     it('Executes a shader with many constant values', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillConstShader);
         const image = fim.createImage(TestSizes.smallWide);
@@ -110,7 +110,7 @@ export function fimTestSuiteWebGL(
 
     it('Executes a shader with many uniform values', async () => {
       // This test case also tests reusing a shader for many executeAsync() calls
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillUniformShader);
         const image = fim.createImage(TestSizes.smallWide);
@@ -128,7 +128,7 @@ export function fimTestSuiteWebGL(
     });
 
     it('Executes a copy shader (nearest sampling)', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         // Generate an input test pattern
         const input = fim.createImage(TestSizes.smallWide);
         input.imageOptions.sampling = FimTextureSampling.Nearest;
@@ -146,7 +146,7 @@ export function fimTestSuiteWebGL(
     });
 
     it('Executes a copy shader (linear sampling)', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         // Generate an input test pattern
         const input = fim.createImage(TestSizes.smallWide);
         input.imageOptions.sampling = FimTextureSampling.Linear;
@@ -164,21 +164,21 @@ export function fimTestSuiteWebGL(
     });
 
     it('Throws on invalid constant name', () => {
-      using(factory(TestSizes.smallWide), fim => {
+      using(factory(), fim => {
         const shader = fim.createGLShader(fillConstShader);
         expect(() => shader.setConstant('cInvalid', 0.5)).toThrow();
       });
     });
 
     it('Throws on invalid uniform name', () => {
-      using(factory(TestSizes.smallWide), fim => {
+      using(factory(), fim => {
         const shader = fim.createGLShader(fillUniformShader);
         expect(() => shader.setUniform('uInvalid', 0.5)).toThrow();
       });
     });
 
     it('Throws on missing constants', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const shader = fim.createGLShader(fillConstShader);
         const image = fim.createImage(TestSizes.smallWide);
 
@@ -188,7 +188,7 @@ export function fimTestSuiteWebGL(
     });
 
     it('Throws on missing uniforms', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const shader = fim.createGLShader(fillUniformShader);
         const image = fim.createImage(TestSizes.smallWide);
 

--- a/packages/fim-common-tests/src/api/WebGL.ts
+++ b/packages/fim-common-tests/src/api/WebGL.ts
@@ -40,7 +40,7 @@ export function fimTestSuiteWebGL(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillConstShader);
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
 
         // Execute the shader
         shader.setConstants({
@@ -58,7 +58,7 @@ export function fimTestSuiteWebGL(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillUniformShader);
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
 
         // Execute the shader
         shader.setUniforms({
@@ -74,12 +74,12 @@ export function fimTestSuiteWebGL(
     it('Executes a shader with an image parameter', async () => {
       await usingAsync(factory(TestSizes.smallSquare), async fim => {
         // Load the four squares sample on to an image
-        const srcImage = fim.createImage();
+        const srcImage = fim.createImage(TestSizes.smallSquare);
         await srcImage.loadFromPngAsync(TestImages.fourSquaresPng());
 
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(copyShader);
-        const destImage = fim.createImage();
+        const destImage = fim.createImage(TestSizes.smallSquare);
 
         // Execute the shader
         shader.setUniform('uInput', srcImage);
@@ -94,7 +94,7 @@ export function fimTestSuiteWebGL(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillConstShader);
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
 
         for (let color = 0; color < 1; color += 0.01) {
           // Execute the shader
@@ -113,7 +113,7 @@ export function fimTestSuiteWebGL(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillUniformShader);
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
 
         for (let color = 0; color < 1; color += 0.01) {
           // Execute the shader
@@ -130,12 +130,12 @@ export function fimTestSuiteWebGL(
     it('Executes a copy shader (nearest sampling)', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         // Generate an input test pattern
-        const input = fim.createImage();
+        const input = fim.createImage(TestSizes.smallWide);
         input.imageOptions.sampling = FimTextureSampling.Nearest;
         await TestPatterns.renderAsync(input, TestPatterns.copyStress);
 
         // Copy the input to an output image using a WebGL copy shader
-        const output = fim.createImage();
+        const output = fim.createImage(TestSizes.smallWide);
         const shader = fim.createGLShader(copyShader);
         shader.setUniform('uInput', input);
         await output.executeAsync(shader);
@@ -148,12 +148,12 @@ export function fimTestSuiteWebGL(
     it('Executes a copy shader (linear sampling)', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         // Generate an input test pattern
-        const input = fim.createImage();
+        const input = fim.createImage(TestSizes.smallWide);
         input.imageOptions.sampling = FimTextureSampling.Linear;
         await TestPatterns.renderAsync(input, TestPatterns.copyStress);
 
         // Copy the input to an output image using a WebGL copy shader
-        const output = fim.createImage();
+        const output = fim.createImage(TestSizes.smallWide);
         const shader = fim.createGLShader(copyShader);
         shader.setUniform('uInput', input);
         await output.executeAsync(shader);
@@ -180,7 +180,7 @@ export function fimTestSuiteWebGL(
     it('Throws on missing constants', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const shader = fim.createGLShader(fillConstShader);
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
 
         // Missing constant cColor
         (await expectErrorAsync(image.executeAsync(shader))).toBeInstanceOf(FimError);
@@ -190,7 +190,7 @@ export function fimTestSuiteWebGL(
     it('Throws on missing uniforms', async () => {
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const shader = fim.createGLShader(fillUniformShader);
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
 
         // Missing uniform uColor
         (await expectErrorAsync(image.executeAsync(shader))).toBeInstanceOf(FimError);

--- a/packages/fim-common-tests/src/api/WebGLAutoscale.ts
+++ b/packages/fim-common-tests/src/api/WebGLAutoscale.ts
@@ -2,11 +2,12 @@
 // Copyright (c) Leo C. Singleton IV <leo@leosingleton.com>
 // See LICENSE in the project root for license information.
 
+import { EngineInternals } from '../common/EngineInternals';
+import { midpoint } from '../common/Globals';
 import { TestColors } from '../common/TestColors';
 import { TestSizes } from '../common/TestSizes';
 import { usingAsync } from '@leosingleton/commonlibs';
 import { Fim, FimOpFill } from '@leosingleton/fim';
-import { EngineInternals } from '../common/EngineInternals';
 
 /** FIM unit tests for the auto-scaling of the underlying WebGL canvas */
 export function fimTestSuiteWebGLAutoscale(
@@ -20,11 +21,35 @@ export function fimTestSuiteWebGLAutoscale(
         const fill = new FimOpFill(fim);
 
         // Perform a WebGL operation on a 128x32 image
-        const input = fim.createImage(TestSizes.smallWide);
-        await input.executeAsync(fill.$(TestColors.red));
+        const image = fim.createImage(TestSizes.smallWide);
+        await image.executeAsync(fill.$(TestColors.red));
 
         // The WebGL canvas should be 128x32
         expect(EngineInternals.getWebGLCanvas(fim).dim).toEqual(TestSizes.smallWide);
+      });
+    });
+
+    it('Resizes WebGL for larger images and preserves image contents', async () => {
+      await usingAsync(factory(), async fim => {
+        const fill = new FimOpFill(fim);
+
+        // Perform a WebGL operation on a 128x32 image
+        const image1 = fim.createImage(TestSizes.smallWide);
+        await image1.executeAsync(fill.$(TestColors.red));
+
+        // The WebGL canvas should be 128x32
+        expect(EngineInternals.getWebGLCanvas(fim).dim).toEqual(TestSizes.smallWide);
+
+        // Perform a WebGL operation on a 32x128 image
+        const image2 = fim.createImage(TestSizes.smallTall);
+        await image2.executeAsync(fill.$(TestColors.blue));
+
+        // The WebGL canvas should now be 128x128
+        expect(EngineInternals.getWebGLCanvas(fim).dim).toEqual(TestSizes.smallSquare);
+
+        // Both images should have the correct color, as image1 was backed up to a 2D canvas during resizing
+        expect(await image1.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);
+        expect(await image2.getPixelAsync(midpoint(TestSizes.smallTall))).toEqual(TestColors.blue);
       });
     });
 

--- a/packages/fim-common-tests/src/api/WebGLAutoscale.ts
+++ b/packages/fim-common-tests/src/api/WebGLAutoscale.ts
@@ -1,0 +1,32 @@
+// FIM - Fast Image Manipulation Library for Javascript
+// Copyright (c) Leo C. Singleton IV <leo@leosingleton.com>
+// See LICENSE in the project root for license information.
+
+import { TestColors } from '../common/TestColors';
+import { TestSizes } from '../common/TestSizes';
+import { usingAsync } from '@leosingleton/commonlibs';
+import { Fim, FimOpFill } from '@leosingleton/fim';
+import { EngineInternals } from '../common/EngineInternals';
+
+/** FIM unit tests for the auto-scaling of the underlying WebGL canvas */
+export function fimTestSuiteWebGLAutoscale(
+  description: string,
+  factory: () => Fim
+): void {
+  describe(`FIM WebGL Autoscale - ${description}`, () => {
+
+    it('Sizes WebGL canvas to image size', async () => {
+      await usingAsync(factory(), async fim => {
+        const fill = new FimOpFill(fim);
+
+        // Perform a WebGL operation on a 128x32 image
+        const input = fim.createImage(TestSizes.smallWide);
+        await input.executeAsync(fill.$(TestColors.red));
+
+        // The WebGL canvas should be 128x32
+        expect(EngineInternals.getWebGLCanvas(fim).dim).toEqual(TestSizes.smallWide);
+      });
+    });
+
+  });
+}

--- a/packages/fim-common-tests/src/api/WebGLContextLost.ts
+++ b/packages/fim-common-tests/src/api/WebGLContextLost.ts
@@ -8,7 +8,7 @@ import { fillUniformShader } from '../common/Shaders';
 import { TestColors } from '../common/TestColors';
 import { TestSizes } from '../common/TestSizes';
 import { usingAsync } from '@leosingleton/commonlibs';
-import { Fim, FimDimensions } from '@leosingleton/fim';
+import { Fim } from '@leosingleton/fim';
 import { EngineFim } from '@leosingleton/fim/internals';
 
 /**
@@ -38,12 +38,12 @@ function restoreFimContextAsync(fim: Fim): Promise<void> {
 /** WebGL Context Lost tests for FIM */
 export function fimTestSuiteWebGLContextLost(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FIM WebGL Context Lost - ${description}`, () => {
 
     it('Simulate a context loss', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         expect(fim.isContextLost()).toBeFalsy();
         await loseFimContextAsync(fim);
         expect(fim.isContextLost()).toBeTruthy();
@@ -51,7 +51,7 @@ export function fimTestSuiteWebGLContextLost(
     });
 
     it('Simulate a context loss and restore', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         expect(fim.isContextLost()).toBeFalsy();
         await loseFimContextAsync(fim);
         expect(fim.isContextLost()).toBeTruthy();
@@ -61,7 +61,7 @@ export function fimTestSuiteWebGLContextLost(
     });
 
     it('Allows handlers to be registered', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         let isLost = 0, isRestored = 0;
 
         fim.registerContextLostHandler(() => {
@@ -88,14 +88,14 @@ export function fimTestSuiteWebGLContextLost(
     });
 
     it('Shaders automatically recover from context loss', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillUniformShader);
         const image = fim.createImage(TestSizes.smallWide);
         expect(image.hasImage()).toBeFalsy();
 
         // Execute the shader to fill the destination texture with red
-        shader.setUniform('uColor', [1, 0, 0, 1]);
+        shader.setUniform('uColor', TestColors.red.toVector());
         await image.executeAsync(shader);
         expect(image.hasImage()).toBeTruthy();
 
@@ -105,7 +105,7 @@ export function fimTestSuiteWebGLContextLost(
         expect(image.hasImage()).toBeFalsy();
 
         // Execute the shader to fill the destination texture with green
-        shader.setUniform('uColor', [0, 1, 0, 1]);
+        shader.setUniform('uColor', TestColors.green.toVector());
         await image.executeAsync(shader);
         expect(image.hasImage()).toBeTruthy();
 
@@ -115,7 +115,7 @@ export function fimTestSuiteWebGLContextLost(
     });
 
     it('fillColorOnContextLost works', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         fim.defaultImageOptions.fillColorOnContextLost = TestColors.blue;
 
         // Create a WebGL shader and destination image
@@ -124,7 +124,7 @@ export function fimTestSuiteWebGLContextLost(
         expect(image.hasImage()).toBeFalsy();
 
         // Execute the shader to fill the destination texture with red
-        shader.setUniform('uColor', [1, 0, 0, 1]);
+        shader.setUniform('uColor', TestColors.red.toVector());
         await image.executeAsync(shader);
         expect(image.hasImage()).toBeTruthy();
 

--- a/packages/fim-common-tests/src/api/WebGLContextLost.ts
+++ b/packages/fim-common-tests/src/api/WebGLContextLost.ts
@@ -8,19 +8,17 @@ import { fillUniformShader } from '../common/Shaders';
 import { TestColors } from '../common/TestColors';
 import { TestSizes } from '../common/TestSizes';
 import { usingAsync } from '@leosingleton/commonlibs';
-import { Fim, FimDimensions } from '@leosingleton/fim';
+import { Fim } from '@leosingleton/fim';
 import { EngineFim } from '@leosingleton/fim/internals';
-
-const tinyDimensions = FimDimensions.fromSquareDimension(1);
 
 /**
  * Forces a WebGL context loss for test purposes
  * @param fim FIM instance
  */
-async function loseFimContextAsync(fim: Fim): Promise<void> {
+function loseFimContextAsync(fim: Fim): Promise<void> {
   // Typecast to an internal engine object to get access to the CoreCanvasWebGL instance
   const engine = fim as EngineFim;
-  const canvas = await engine.getWebGLCanvas(tinyDimensions);
+  const canvas = engine.getWebGLCanvas();
 
   return loseContextAsync(canvas);
 }
@@ -29,10 +27,10 @@ async function loseFimContextAsync(fim: Fim): Promise<void> {
  * Forces the WebGL context to be restored for test purposes
  * @param fim FIM instance
  */
-async function restoreFimContextAsync(fim: Fim): Promise<void> {
+function restoreFimContextAsync(fim: Fim): Promise<void> {
   // Typecast to an internal engine object to get access to the CoreCanvasWebGL instance
   const engine = fim as EngineFim;
-  const canvas = await engine.getWebGLCanvas(tinyDimensions);
+  const canvas = engine.getWebGLCanvas();
 
   return restoreContextAsync(canvas);
 }

--- a/packages/fim-common-tests/src/api/WebGLContextLost.ts
+++ b/packages/fim-common-tests/src/api/WebGLContextLost.ts
@@ -91,7 +91,7 @@ export function fimTestSuiteWebGLContextLost(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillUniformShader);
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         expect(image.hasImage()).toBeFalsy();
 
         // Execute the shader to fill the destination texture with red
@@ -120,7 +120,7 @@ export function fimTestSuiteWebGLContextLost(
 
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillUniformShader);
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         expect(image.hasImage()).toBeFalsy();
 
         // Execute the shader to fill the destination texture with red

--- a/packages/fim-common-tests/src/api/WebGLContextLost.ts
+++ b/packages/fim-common-tests/src/api/WebGLContextLost.ts
@@ -8,17 +8,19 @@ import { fillUniformShader } from '../common/Shaders';
 import { TestColors } from '../common/TestColors';
 import { TestSizes } from '../common/TestSizes';
 import { usingAsync } from '@leosingleton/commonlibs';
-import { Fim } from '@leosingleton/fim';
+import { Fim, FimDimensions } from '@leosingleton/fim';
 import { EngineFim } from '@leosingleton/fim/internals';
+
+const onePixel = FimDimensions.fromSquareDimension(1);
 
 /**
  * Forces a WebGL context loss for test purposes
  * @param fim FIM instance
  */
-function loseFimContextAsync(fim: Fim): Promise<void> {
+async function loseFimContextAsync(fim: Fim): Promise<void> {
   // Typecast to an internal engine object to get access to the CoreCanvasWebGL instance
   const engine = fim as EngineFim;
-  const canvas = engine.getWebGLCanvas();
+  const canvas = await engine.allocateWebGLCanvasAsync(onePixel);
 
   return loseContextAsync(canvas);
 }
@@ -27,10 +29,10 @@ function loseFimContextAsync(fim: Fim): Promise<void> {
  * Forces the WebGL context to be restored for test purposes
  * @param fim FIM instance
  */
-function restoreFimContextAsync(fim: Fim): Promise<void> {
+async function restoreFimContextAsync(fim: Fim): Promise<void> {
   // Typecast to an internal engine object to get access to the CoreCanvasWebGL instance
   const engine = fim as EngineFim;
-  const canvas = engine.getWebGLCanvas();
+  const canvas = await engine.allocateWebGLCanvasAsync(onePixel);
 
   return restoreContextAsync(canvas);
 }

--- a/packages/fim-common-tests/src/api/WebGLContextLost.ts
+++ b/packages/fim-common-tests/src/api/WebGLContextLost.ts
@@ -8,17 +8,19 @@ import { fillUniformShader } from '../common/Shaders';
 import { TestColors } from '../common/TestColors';
 import { TestSizes } from '../common/TestSizes';
 import { usingAsync } from '@leosingleton/commonlibs';
-import { Fim } from '@leosingleton/fim';
+import { Fim, FimDimensions } from '@leosingleton/fim';
 import { EngineFim } from '@leosingleton/fim/internals';
+
+const tinyDimensions = FimDimensions.fromSquareDimension(1);
 
 /**
  * Forces a WebGL context loss for test purposes
  * @param fim FIM instance
  */
-function loseFimContextAsync(fim: Fim): Promise<void> {
+async function loseFimContextAsync(fim: Fim): Promise<void> {
   // Typecast to an internal engine object to get access to the CoreCanvasWebGL instance
   const engine = fim as EngineFim;
-  const canvas = engine.getWebGLCanvas();
+  const canvas = await engine.getWebGLCanvas(tinyDimensions);
 
   return loseContextAsync(canvas);
 }
@@ -27,10 +29,10 @@ function loseFimContextAsync(fim: Fim): Promise<void> {
  * Forces the WebGL context to be restored for test purposes
  * @param fim FIM instance
  */
-function restoreFimContextAsync(fim: Fim): Promise<void> {
+async function restoreFimContextAsync(fim: Fim): Promise<void> {
   // Typecast to an internal engine object to get access to the CoreCanvasWebGL instance
   const engine = fim as EngineFim;
-  const canvas = engine.getWebGLCanvas();
+  const canvas = await engine.getWebGLCanvas(tinyDimensions);
 
   return restoreContextAsync(canvas);
 }

--- a/packages/fim-common-tests/src/api/WebGLTransform.ts
+++ b/packages/fim-common-tests/src/api/WebGLTransform.ts
@@ -7,17 +7,17 @@ import { fillUniformShader } from '../common/Shaders';
 import { TestColors } from '../common/TestColors';
 import { TestSizes } from '../common/TestSizes';
 import { usingAsync } from '@leosingleton/commonlibs';
-import { Fim, FimDimensions, FimOpCopy, FimTransform2D, FimTransform3D, FimTwoTriangles } from '@leosingleton/fim';
+import { Fim, FimOpCopy, FimTransform2D, FimTransform3D, FimTwoTriangles } from '@leosingleton/fim';
 
 /** WebGL tests for FIM with vertex transformation*/
 export function fimTestSuiteWebGLTransform(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FIM WebGL Transform - ${description}`, () => {
 
     it('Executes a shader with vertex positions and texture coords', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillUniformShader);
         const image = fim.createImage(TestSizes.smallWide);
@@ -36,7 +36,7 @@ export function fimTestSuiteWebGLTransform(
     });
 
     it('Executes a shader with a vertex matrix', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillUniformShader);
         const image = fim.createImage(TestSizes.smallWide);
@@ -55,7 +55,7 @@ export function fimTestSuiteWebGLTransform(
     });
 
     it('Preserves background with vertex matrices', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const copy = new FimOpCopy(fim);
 
         const red = fim.createImage(TestSizes.smallWide);

--- a/packages/fim-common-tests/src/api/WebGLTransform.ts
+++ b/packages/fim-common-tests/src/api/WebGLTransform.ts
@@ -20,7 +20,7 @@ export function fimTestSuiteWebGLTransform(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillUniformShader);
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         await image.fillSolidAsync(TestColors.black);
 
         // Execute the shader
@@ -39,7 +39,7 @@ export function fimTestSuiteWebGLTransform(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         // Create a WebGL shader and destination image
         const shader = fim.createGLShader(fillUniformShader);
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         await image.fillSolidAsync(TestColors.black);
 
         // Execute the shader
@@ -58,10 +58,10 @@ export function fimTestSuiteWebGLTransform(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const copy = new FimOpCopy(fim);
 
-        const red = fim.createImage();
+        const red = fim.createImage(TestSizes.smallWide);
         await red.fillSolidAsync(TestColors.red);
 
-        const output = fim.createImage();
+        const output = fim.createImage(TestSizes.smallWide);
         await output.fillSolidAsync(TestColors.blue);
 
         // Copy red, shifted down and to the right 50%

--- a/packages/fim-common-tests/src/common/EngineInternals.ts
+++ b/packages/fim-common-tests/src/common/EngineInternals.ts
@@ -1,0 +1,14 @@
+// FIM - Fast Image Manipulation Library for Javascript
+// Copyright (c) Leo C. Singleton IV <leo@leosingleton.com>
+// See LICENSE in the project root for license information.
+
+import { Fim } from '@leosingleton/fim';
+import { CoreCanvasWebGL } from '@leosingleton/fim/internals';
+
+/** Helper functions for accessing the internals of the `Fim` class */
+export namespace EngineInternals {
+  /** Returns the `CoreCanvasWebGL` instance backing the FIM engine */
+  export function getWebGLCanvas(fim: Fim): CoreCanvasWebGL {
+    return (fim as any).glCanvas;
+  }
+}

--- a/packages/fim-common-tests/src/common/TestSizes.ts
+++ b/packages/fim-common-tests/src/common/TestSizes.ts
@@ -12,6 +12,9 @@ export namespace TestSizes {
   /** Small 128x128 dimensions, also used by the four squares sample images */
   export const smallSquare = FimDimensions.fromSquareDimension(128);
 
+  /** Small 32x128 dimensions */
+  export const smallTall = FimDimensions.fromWidthHeight(32, 128);
+
   /** Medium 640x160 dimensions */
   export const mediumWide = FimDimensions.fromWidthHeight(640, 160);
 
@@ -23,4 +26,10 @@ export namespace TestSizes {
 
   /** Large 1920x480 dimensions */
   export const largeWide = FimDimensions.fromWidthHeight(1920, 480);
+
+  /** Large 1920x1920 dimensions */
+  export const largeSquare = FimDimensions.fromSquareDimension(1920);
+
+  /** Large 480x1920 dimensions */
+  export const largeTall = FimDimensions.fromWidthHeight(480, 1920);
 }

--- a/packages/fim-common-tests/src/core/CoreCanvas2D/Canvas.ts
+++ b/packages/fim-common-tests/src/core/CoreCanvas2D/Canvas.ts
@@ -14,12 +14,12 @@ import { CoreCanvas2D, CoreCanvasOptions,  } from '@leosingleton/fim/internals';
 /** CoreCanvas2D test cases around canvases */
 export function coreCanvas2DTestSuiteCanvas(
   description: string,
-  factory: (canvasOptions: CoreCanvasOptions, dimensions: FimDimensions) => CoreCanvas2D
+  factory: (dimensions: FimDimensions, canvasOptions: CoreCanvasOptions) => CoreCanvas2D
 ): void {
   describe(`CoreCanvas2D Canvas - ${description}`, () => {
 
     it('Gets and sets pixels', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallWide), async canvas => {
+      await usingAsync(factory(TestSizes.smallWide, canvasOptions), async canvas => {
         const pixelData = TestImages.solidPixelData(TestSizes.smallWide, TestColors.red);
         await canvas.loadPixelDataAsync(pixelData);
         expect(canvas.getPixel(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);
@@ -27,17 +27,17 @@ export function coreCanvas2DTestSuiteCanvas(
     });
 
     it('Fills with solid colors', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         canvas.fillSolid(TestColors.green);
         expect(canvas.getPixel(midpoint(TestSizes.smallWide))).toEqual(TestColors.green);
       });
     });
 
     it('Copies from one canvas to another', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallWide), async canvas1 => {
+      await usingAsync(factory(TestSizes.smallWide, canvasOptions), async canvas1 => {
         canvas1.fillSolid(TestColors.blue);
 
-        await usingAsync(factory(canvasOptions, TestSizes.smallWide), async canvas2 => {
+        await usingAsync(factory(TestSizes.smallWide, canvasOptions), async canvas2 => {
           await canvas2.copyFromAsync(canvas1);
           expect(canvas2.getPixel(midpoint(TestSizes.smallWide))).toEqual(TestColors.blue);
         });
@@ -45,7 +45,7 @@ export function coreCanvas2DTestSuiteCanvas(
     });
 
     it('Exports to pixel data', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         canvas.fillSolid(TestColors.red);
         const data = canvas.exportToPixelData();
 
@@ -58,7 +58,7 @@ export function coreCanvas2DTestSuiteCanvas(
     });
 
     it('Exports a region to pixel data', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallSquare), async canvas => {
+      await usingAsync(factory(TestSizes.smallSquare, canvasOptions), async canvas => {
         // Load the four squares test pattern
         await canvas.loadFromPngAsync(TestImages.fourSquaresPng());
 

--- a/packages/fim-common-tests/src/core/CoreCanvas2D/CreateDispose.ts
+++ b/packages/fim-common-tests/src/core/CoreCanvas2D/CreateDispose.ts
@@ -10,12 +10,12 @@ import { CoreCanvas2D, CoreCanvasOptions } from '@leosingleton/fim/internals';
 /** CoreCanvas2D tests around create/dispose */
 export function coreCanvas2DTestSuiteCreateDispose(
   description: string,
-  factory: (canvasOptions: CoreCanvasOptions, dimensions: FimDimensions) => CoreCanvas2D
+  factory: (dimensions: FimDimensions, canvasOptions: CoreCanvasOptions) => CoreCanvas2D
 ): void {
   describe(`CoreCanvas2D Create/Dispose - ${description}`, () => {
 
     it('Creates and disposes', () => {
-      const canvas = factory(canvasOptions, TestSizes.smallWide);
+      const canvas = factory(TestSizes.smallWide, canvasOptions);
       canvas.dispose();
       expect(() => canvas.dispose()).toThrow(); // Double dispose throws exception
     });

--- a/packages/fim-common-tests/src/core/CoreCanvas2D/PngJpeg.ts
+++ b/packages/fim-common-tests/src/core/CoreCanvas2D/PngJpeg.ts
@@ -12,12 +12,12 @@ import { CoreCanvas2D, CoreCanvasOptions } from '@leosingleton/fim/internals';
 /** CoreCanvas2D test cases for PNG and JPEG support */
 export function coreCanvas2DTestSuitePngJpeg(
   description: string,
-  factory: (canvasOptions: CoreCanvasOptions, dimensions: FimDimensions) => CoreCanvas2D
+  factory: (dimensions: FimDimensions, canvasOptions: CoreCanvasOptions) => CoreCanvas2D
 ): void {
   describe(`CoreCanvas2D PNG/JPEG - ${description}`, () => {
 
     it('Imports from PNG', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallSquare), async canvas => {
+      await usingAsync(factory(TestSizes.smallSquare, canvasOptions), async canvas => {
         const png = TestImages.fourSquaresPng();
         await canvas.loadFromPngAsync(png);
         await TestImages.expectFourSquaresPngCanvasAsync(canvas);
@@ -25,7 +25,7 @@ export function coreCanvas2DTestSuitePngJpeg(
     });
 
     it('Imports from JPEG', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallSquare), async canvas => {
+      await usingAsync(factory(TestSizes.smallSquare, canvasOptions), async canvas => {
         const jpeg = TestImages.fourSquaresJpeg();
         await canvas.loadFromJpegAsync(jpeg);
         await TestImages.expectFourSquaresJpegCanvasAsync(canvas);
@@ -33,7 +33,7 @@ export function coreCanvas2DTestSuitePngJpeg(
     });
 
     it('Imports from PNG with rescale', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.mediumTall), async canvas => {
+      await usingAsync(factory(TestSizes.mediumTall, canvasOptions), async canvas => {
         const png = TestImages.fourSquaresPng();
         await canvas.loadFromPngAsync(png);
         await TestImages.expectFourSquaresPngCanvasAsync(canvas);
@@ -41,7 +41,7 @@ export function coreCanvas2DTestSuitePngJpeg(
     });
 
     it('Imports from JPEG with rescale', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.mediumTall), async canvas => {
+      await usingAsync(factory(TestSizes.mediumTall, canvasOptions), async canvas => {
         const jpeg = TestImages.fourSquaresJpeg();
         await canvas.loadFromJpegAsync(jpeg);
         await TestImages.expectFourSquaresJpegCanvasAsync(canvas);

--- a/packages/fim-common-tests/src/core/CoreCanvasWebGL/Canvas.ts
+++ b/packages/fim-common-tests/src/core/CoreCanvasWebGL/Canvas.ts
@@ -14,12 +14,12 @@ import { CoreCanvasOptions, CoreCanvasWebGL, CoreTexture } from '@leosingleton/f
 /** CoreCanvasWebGL test cases for canvas operations */
 export function coreCanvasWebGLTestSuiteCanvas(
   description: string,
-  factory: (canvasOptions: CoreCanvasOptions, dimensions: FimDimensions) => CoreCanvasWebGL
+  factory: (dimensions: FimDimensions, canvasOptions: CoreCanvasOptions) => CoreCanvasWebGL
 ): void {
   describe(`CoreCanvasWebGL Canvas - ${description}`, () => {
 
     it('Fills with solid colors', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         canvas.fillSolid(TestColors.red);
         expect(canvas.getPixel(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);
         canvas.fillSolid(TestColors.green);
@@ -30,9 +30,9 @@ export function coreCanvasWebGLTestSuiteCanvas(
     });
 
     it('Copies from textures 1', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         // Create a texture of solid blue
-        const texture = canvas.createCoreTexture(textureOptions);
+        const texture = canvas.createCoreTexture(TestSizes.smallWide, textureOptions);
         texture.fillSolid(TestColors.blue);
 
         // Fill the WebGL canvas with green
@@ -48,13 +48,13 @@ export function coreCanvasWebGLTestSuiteCanvas(
     });
 
     it('Copies from textures 2', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallWide), async canvas => {
+      await usingAsync(factory(TestSizes.smallWide, canvasOptions), async canvas => {
         // Create a canvas of solid red
         const temp = canvas.createTemporaryCanvas2D();
         temp.fillSolid(TestColors.red);
 
         // Copy the canvas to a texture
-        const texture = canvas.createCoreTexture(textureOptions);
+        const texture = canvas.createCoreTexture(TestSizes.smallWide, textureOptions);
         await texture.copyFromAsync(temp);
 
         // Fill the WebGL canvas with green
@@ -70,7 +70,7 @@ export function coreCanvasWebGLTestSuiteCanvas(
     });
 
     it('Copies from textures 3', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallSquare), async canvas => {
+      await usingAsync(factory(TestSizes.smallSquare, canvasOptions), async canvas => {
         // Create a test image the size of the canvas
         const texture = await createFourSquaresTexture(canvas);
 
@@ -87,7 +87,7 @@ export function coreCanvasWebGLTestSuiteCanvas(
     });
 
     it('Copies from textures with srcCoords', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.mediumTall), async canvas => {
+      await usingAsync(factory(TestSizes.mediumTall, canvasOptions), async canvas => {
         // Create a test image the size of the canvas
         const texture = await createFourSquaresTexture(canvas);
 
@@ -107,7 +107,7 @@ export function coreCanvasWebGLTestSuiteCanvas(
     });
 
     it('Copies from textures with srcCoords and destCoords', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.mediumTall), async canvas => {
+      await usingAsync(factory(TestSizes.mediumTall, canvasOptions), async canvas => {
         // Create a test image the size of the canvas
         const texture = await createFourSquaresTexture(canvas, TestSizes.mediumTall);
 
@@ -139,10 +139,10 @@ export function coreCanvasWebGLTestSuiteCanvas(
  */
 async function createFourSquaresTexture(canvas: CoreCanvasWebGL, dimensions = TestSizes.smallSquare):
     Promise<CoreTexture> {
-  const texture = canvas.createCoreTexture(textureOptions, dimensions);
+  const texture = canvas.createCoreTexture(dimensions, textureOptions);
 
   // Load the JPEG to a temporary canvas then copy it to the texture
-  await usingAsync(canvas.createTemporaryCanvas2D(canvasOptions, dimensions), async temp => {
+  await usingAsync(canvas.createTemporaryCanvas2D(dimensions, canvasOptions), async temp => {
     const jpeg = TestImages.fourSquaresPng();
     await temp.loadFromJpegAsync(jpeg);
     await texture.copyFromAsync(temp);

--- a/packages/fim-common-tests/src/core/CoreCanvasWebGL/Capabilities.ts
+++ b/packages/fim-common-tests/src/core/CoreCanvasWebGL/Capabilities.ts
@@ -11,26 +11,26 @@ import { CoreCanvasOptions, CoreCanvasWebGL } from '@leosingleton/fim/internals'
 /** CoreCanvasWebGL test cases for capabilities */
 export function coreCanvasWebGLTestSuiteCapabilities(
   description: string,
-  factory: (canvasOptions: CoreCanvasOptions, dimensions: FimDimensions) => CoreCanvasWebGL
+  factory: (dimensions: FimDimensions, canvasOptions: CoreCanvasOptions) => CoreCanvasWebGL
 ): void {
   describe(`CoreCanvasWebGL Capabilities - ${description}`, () => {
 
     it('Calculates max texture depth with linear filtering', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         const bpp = canvas.getSupportedColorDepths(FimTextureSampling.Linear);
         expect(bpp).toContain(FimBitsPerPixel.BPP8);
       });
     });
 
     it('Calculates max texture depth with nearest filtering', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         const bpp = canvas.getSupportedColorDepths(FimTextureSampling.Nearest);
         expect(bpp).toContain(FimBitsPerPixel.BPP8);
       });
     });
 
     it('Detects capabilities', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         const caps = canvas.detectCapabilities();
         expect(caps.glMaxRenderBufferSize).toBeGreaterThan(0);
         expect(caps.glMaxTextureImageUnits).toBeGreaterThan(0);

--- a/packages/fim-common-tests/src/core/CoreCanvasWebGL/ContextLost.ts
+++ b/packages/fim-common-tests/src/core/CoreCanvasWebGL/ContextLost.ts
@@ -14,12 +14,12 @@ import { CoreCanvasOptions, CoreCanvasWebGL } from '@leosingleton/fim/internals'
 /** CoreCanvasWebGL test cases for context lost simulation */
 export function coreCanvasWebGLTestSuiteContextLost(
   description: string,
-  factory: (canvasOptions: CoreCanvasOptions, dimensions: FimDimensions) => CoreCanvasWebGL
+  factory: (dimensions: FimDimensions, canvasOptions: CoreCanvasOptions) => CoreCanvasWebGL
 ): void {
   describe(`CoreCanvasWebGL Context Lost - ${description}`, () => {
 
     it('Simulate a context loss', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallWide), async canvas => {
+      await usingAsync(factory(TestSizes.smallWide, canvasOptions), async canvas => {
         // Simulate a context loss
         expect(canvas.isContextLost).toBeFalsy();
         await loseContextAsync(canvas);
@@ -31,7 +31,7 @@ export function coreCanvasWebGLTestSuiteContextLost(
     });
 
     it('Simulate a context loss and restored', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallWide), async canvas => {
+      await usingAsync(factory(TestSizes.smallWide, canvasOptions), async canvas => {
         // Simulate a context loss and immediate restore
         expect(canvas.isContextLost).toBeFalsy();
         await loseContextAsync(canvas);
@@ -46,12 +46,12 @@ export function coreCanvasWebGLTestSuiteContextLost(
     });
 
     it('Simulate a complex context loss', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallWide), async canvas => {
+      await usingAsync(factory(TestSizes.smallWide, canvasOptions), async canvas => {
         // Fill the WebGL canvas with red
         canvas.fillSolid(TestColors.red);
 
         // Create a green texture
-        const texture1 = canvas.createCoreTexture(textureOptions);
+        const texture1 = canvas.createCoreTexture(TestSizes.smallWide, textureOptions);
         texture1.fillSolid(TestColors.green);
 
         // The image data on the canvas and texture is now valid
@@ -81,7 +81,7 @@ export function coreCanvasWebGLTestSuiteContextLost(
         expect(() => texture1.dispose()).toThrow();
 
         // Create a new texture and copy it to the WebGL canvas, this time with blue
-        const texture2 = canvas.createCoreTexture(textureOptions);
+        const texture2 = canvas.createCoreTexture(TestSizes.smallWide, textureOptions);
         texture2.fillSolid(TestColors.blue);
         canvas.copyFrom(texture2);
         expect(canvas.getPixel(midpoint(TestSizes.smallWide))).toEqual(TestColors.blue);

--- a/packages/fim-common-tests/src/core/CoreCanvasWebGL/CreateDispose.ts
+++ b/packages/fim-common-tests/src/core/CoreCanvasWebGL/CreateDispose.ts
@@ -12,18 +12,18 @@ import { CoreCanvasOptions, CoreCanvasWebGL } from '@leosingleton/fim/internals'
 /** CoreCanvasWebGL test cases for create/dispose */
 export function coreCanvasWebGLTestSuiteCreateDispose(
   description: string,
-  factory: (canvasOptions: CoreCanvasOptions, dimensions: FimDimensions) => CoreCanvasWebGL
+  factory: (dimensions: FimDimensions, canvasOptions: CoreCanvasOptions) => CoreCanvasWebGL
 ): void {
   describe(`CoreCanvasWebGL Create/Dispose - ${description}`, () => {
 
     it('Creates and disposes', () => {
-      const canvas = factory(canvasOptions, TestSizes.smallWide);
+      const canvas = factory(TestSizes.smallWide, canvasOptions);
       canvas.dispose();
       expect(() => canvas.dispose()).toThrow(); // Double dispose throws exception
     });
 
     it('Automatically disposes shaders', () => {
-      const canvas = factory(canvasOptions, TestSizes.smallWide);
+      const canvas = factory(TestSizes.smallWide, canvasOptions);
       const source = require('../../glsl/FillUniform.glsl.js');
       const shader = canvas.createCoreShader(source);
       canvas.dispose();
@@ -31,14 +31,14 @@ export function coreCanvasWebGLTestSuiteCreateDispose(
     });
 
     it('Automatically disposes textures', () => {
-      const canvas = factory(canvasOptions, TestSizes.smallWide);
-      const texture = canvas.createCoreTexture(textureOptions);
+      const canvas = factory(TestSizes.smallWide, canvasOptions);
+      const texture = canvas.createCoreTexture(TestSizes.smallWide, textureOptions);
       canvas.dispose();
       expect(() => texture.dispose()).toThrow(); // Texture is automatically disposed by WebGL canvas
     });
 
     it('Automatically disposes built-in shaders', () => {
-      const canvas = factory(canvasOptions, TestSizes.smallWide);
+      const canvas = factory(TestSizes.smallWide, canvasOptions);
       const copyShader = canvas.getCopyShader();
       const fillShader = canvas.getFillShader();
       canvas.dispose();
@@ -47,7 +47,7 @@ export function coreCanvasWebGLTestSuiteCreateDispose(
     });
 
     it('Does not automatically disposes temporary canvases', () => {
-      const canvas = factory(canvasOptions, TestSizes.smallWide);
+      const canvas = factory(TestSizes.smallWide, canvasOptions);
       const temp = canvas.createTemporaryCanvas2D();
       canvas.dispose();
 
@@ -57,7 +57,7 @@ export function coreCanvasWebGLTestSuiteCreateDispose(
     });
 
     it('getContext() stress', () => {
-      using(factory(canvasOptions, TestSizes.largeWide), canvas => {
+      using(factory(TestSizes.largeWide, canvasOptions), canvas => {
         for (let n = 0; n < 100; n++) {
           canvas.fillSolid(TestColors.red);
           const gl = canvas.getContext();
@@ -68,9 +68,9 @@ export function coreCanvasWebGLTestSuiteCreateDispose(
 
     it('Create/dispose stress', () => {
       for (let n = 0; n < 100; n++) {
-        using(factory(canvasOptions, TestSizes.largeWide), canvas => {
+        using(factory(TestSizes.largeWide, canvasOptions), canvas => {
           canvas.fillSolid(TestColors.red);
-          const texture = canvas.createCoreTexture(textureOptions);
+          const texture = canvas.createCoreTexture(TestSizes.largeWide, textureOptions);
           texture.fillSolid(TestColors.red);
         });
       }

--- a/packages/fim-common-tests/src/core/CoreCanvasWebGL/ExportCopyTo.ts
+++ b/packages/fim-common-tests/src/core/CoreCanvasWebGL/ExportCopyTo.ts
@@ -14,12 +14,12 @@ import { CoreCanvasOptions, CoreCanvasWebGL } from '@leosingleton/fim/internals'
 /** CoreCanvasWebGL test cases for exporting and copying to other objects */
 export function coreCanvasWebGLTestSuiteExportCopyTo(
   description: string,
-  factory: (canvasOptions: CoreCanvasOptions, dimensions: FimDimensions) => CoreCanvasWebGL
+  factory: (dimensions: FimDimensions, canvasOptions: CoreCanvasOptions) => CoreCanvasWebGL
 ): void {
   describe(`CoreCanvasWebGL Export/CopyTo - ${description}`, () => {
 
     it('Exports to pixel data', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         canvas.fillSolid(TestColors.red);
         const data = canvas.exportToPixelData();
 
@@ -32,7 +32,7 @@ export function coreCanvasWebGLTestSuiteExportCopyTo(
     });
 
     it('Exports to pixel data without flipping image', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallSquare), async canvas => {
+      await usingAsync(factory(TestSizes.smallSquare, canvasOptions), async canvas => {
         // Render the four squares test pattern onto a WebGL canvas
         await renderFourSquares(canvas);
 
@@ -48,7 +48,7 @@ export function coreCanvasWebGLTestSuiteExportCopyTo(
     });
 
     it('Exports a region to pixel data', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallSquare), async canvas => {
+      await usingAsync(factory(TestSizes.smallSquare, canvasOptions), async canvas => {
         // Render the four squares test pattern onto a WebGL canvas
         await renderFourSquares(canvas);
 
@@ -66,7 +66,7 @@ export function coreCanvasWebGLTestSuiteExportCopyTo(
     });
 
     it('Copies to a CoreCanvas2D', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallWide), async canvas => {
+      await usingAsync(factory(TestSizes.smallWide, canvasOptions), async canvas => {
         // Fill the WebGL canvas with red
         canvas.fillSolid(TestColors.red);
 
@@ -79,12 +79,12 @@ export function coreCanvasWebGLTestSuiteExportCopyTo(
     });
 
     it('Copies to a CoreTexture', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallWide), async canvas => {
+      await usingAsync(factory(TestSizes.smallWide, canvasOptions), async canvas => {
         // Fill the WebGL canvas with red
         canvas.fillSolid(TestColors.red);
 
         // Copy the WebGL canvas to a CoreTexture
-        const texture = canvas.createCoreTexture(textureOptions);
+        const texture = canvas.createCoreTexture(TestSizes.smallWide, textureOptions);
         await texture.copyFromAsync(canvas);
 
         // Fill the WebGL canvas with green
@@ -103,7 +103,7 @@ export function coreCanvasWebGLTestSuiteExportCopyTo(
 /** Helper function to render the four squares test pattern onto a WebGL canvas */
 async function renderFourSquares(canvas: CoreCanvasWebGL): Promise<void> {
   // Load the four squares test pattern on to a texture
-  const texture = canvas.createCoreTexture(textureOptions);
+  const texture = canvas.createCoreTexture(TestSizes.smallSquare, textureOptions);
   await usingAsync(canvas.createTemporaryCanvas2D(), async temp => {
     await temp.loadFromPngAsync(TestImages.fourSquaresPng());
     await texture.copyFromAsync(temp);

--- a/packages/fim-common-tests/src/core/CoreCanvasWebGL/Shader.ts
+++ b/packages/fim-common-tests/src/core/CoreCanvasWebGL/Shader.ts
@@ -14,12 +14,12 @@ import { CoreCanvasOptions, CoreCanvasWebGL, CoreShader } from '@leosingleton/fi
 /** CoreCanvasWebGL test cases for shaders */
 export function coreCanvasWebGLTestSuiteShader(
   description: string,
-  factory: (canvasOptions: CoreCanvasOptions, dimensions: FimDimensions) => CoreCanvasWebGL
+  factory: (dimensions: FimDimensions, canvasOptions: CoreCanvasOptions) => CoreCanvasWebGL
 ): void {
   describe(`CoreCanvasWebGL Shader - ${description}`, () => {
 
     it('Creates and disposes', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         const shader = canvas.createCoreShader(fillConstShader);
         shader.dispose();
       });
@@ -28,7 +28,7 @@ export function coreCanvasWebGLTestSuiteShader(
     it('Disposes automatically', () => {
       let shader: CoreShader;
 
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         shader = canvas.createCoreShader(fillConstShader);
       });
 
@@ -37,7 +37,7 @@ export function coreCanvasWebGLTestSuiteShader(
     });
 
     it('Executes a simple fill shader', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         const shader = canvas.createCoreShader(fillUniformShader);
 
         // Fill the output with the color red
@@ -52,9 +52,9 @@ export function coreCanvasWebGLTestSuiteShader(
     });
 
     it('Executes a simple fill shader with a constant, outputting to a texture', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         const shader = canvas.createCoreShader(fillConstShader);
-        const texture = canvas.createCoreTexture(textureOptions);
+        const texture = canvas.createCoreTexture(TestSizes.smallWide, textureOptions);
 
         // Fill the texture with the color green
         shader.setConstants({
@@ -71,9 +71,9 @@ export function coreCanvasWebGLTestSuiteShader(
     });
 
     it('Executes a simple fill shader with a uniform, outputting to a texture', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         const shader = canvas.createCoreShader(fillUniformShader);
-        const texture = canvas.createCoreTexture(textureOptions);
+        const texture = canvas.createCoreTexture(TestSizes.smallWide, textureOptions);
 
         // Fill the texture with the color green
         shader.setUniform('uColor', [0, 1, 0, 1]);

--- a/packages/fim-common-tests/src/core/CoreCanvasWebGL/Texture.ts
+++ b/packages/fim-common-tests/src/core/CoreCanvasWebGL/Texture.ts
@@ -14,16 +14,16 @@ import { CoreCanvasOptions, CoreCanvasWebGL, CoreTexture } from '@leosingleton/f
 /** CoreCanvasWebGL test cases for textures */
 export function coreCanvasWebGLTestSuiteTexture(
   description: string,
-  factory: (canvasOptions: CoreCanvasOptions, dimensions: FimDimensions) => CoreCanvasWebGL
+  factory: (dimensions: FimDimensions, canvasOptions: CoreCanvasOptions) => CoreCanvasWebGL
 ): void {
   describe(`CoreCanvasWebGL Texture - ${description}`, () => {
 
     it('Creates and disposes', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
-        const texture1 = canvas.createCoreTexture(textureOptions);
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
+        const texture1 = canvas.createCoreTexture(TestSizes.smallWide, textureOptions);
         texture1.dispose();
 
-        const texture2 = canvas.createCoreTexture(textureOptions);
+        const texture2 = canvas.createCoreTexture(TestSizes.smallWide, textureOptions);
         texture2.dispose();
       });
     });
@@ -31,8 +31,8 @@ export function coreCanvasWebGLTestSuiteTexture(
     it('Disposes automatically', () => {
       let texture: CoreTexture;
 
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
-        texture = canvas.createCoreTexture(textureOptions);
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
+        texture = canvas.createCoreTexture(TestSizes.smallWide, textureOptions);
       });
 
       // Since the parent canvas was disposed, dispose() on the child object will throw an exception
@@ -40,8 +40,8 @@ export function coreCanvasWebGLTestSuiteTexture(
     });
 
     it('Creates readonly', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
-        const texture = canvas.createCoreTexture({
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
+        const texture = canvas.createCoreTexture(TestSizes.smallWide, {
           bpp: FimBitsPerPixel.BPP8, // isReadOnly only supports 8 bits per pixel
           isReadOnly: true,
           sampling: FimTextureSampling.Nearest
@@ -51,8 +51,8 @@ export function coreCanvasWebGLTestSuiteTexture(
     });
 
     it('Fills with solid colors', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
-        const texture = canvas.createCoreTexture(textureOptions);
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
+        const texture = canvas.createCoreTexture(TestSizes.smallWide, textureOptions);
 
         // Fill with red
         texture.fillSolid(TestColors.red);
@@ -71,9 +71,9 @@ export function coreCanvasWebGLTestSuiteTexture(
     });
 
     it('Loads from pixel data', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         // Load a texture with green
-        const texture = canvas.createCoreTexture(textureOptions);
+        const texture = canvas.createCoreTexture(TestSizes.smallWide, textureOptions);
         texture.loadPixelData(TestImages.solidPixelData(TestSizes.smallWide, TestColors.green));
 
         // Ensure the texture is green
@@ -83,11 +83,11 @@ export function coreCanvasWebGLTestSuiteTexture(
     });
 
     it('Supports all combinations of channels, bits per pixel, and flags', async () => {
-      await usingAsync(factory(canvasOptions, TestSizes.smallWide), async canvas => {
+      await usingAsync(factory(TestSizes.smallWide, canvasOptions), async canvas => {
         const caps = canvas.detectCapabilities();
 
         // Create a 2D grey canvas
-        const temp = canvas.createTemporaryCanvas2D(canvasOptions, TestSizes.mediumTall);
+        const temp = canvas.createTemporaryCanvas2D(TestSizes.mediumTall, canvasOptions);
         temp.fillSolid(TestColors.grey);
 
         for (const bpp of [FimBitsPerPixel.BPP8, FimBitsPerPixel.BPP16, FimBitsPerPixel.BPP32]) {
@@ -105,11 +105,11 @@ export function coreCanvasWebGLTestSuiteTexture(
               }
 
               // Create a texture with the requested image options
-              const texture = canvas.createCoreTexture({
+              const texture = canvas.createCoreTexture(TestSizes.mediumTall, {
                 bpp,
                 isReadOnly,
                 sampling
-              }, TestSizes.mediumTall);
+              });
 
               // Copy the 2D grey canvas to the texture
               await texture.copyFromAsync(temp);
@@ -128,22 +128,22 @@ export function coreCanvasWebGLTestSuiteTexture(
     });
 
     it('Prevents creation of oversized textures', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         const caps = canvas.detectCapabilities();
         const dim = FimDimensions.fromWidthHeight(caps.glMaxTextureSize + 1, 10);
-        expect(() => canvas.createCoreTexture({
+        expect(() => canvas.createCoreTexture(dim, {
           bpp: FimBitsPerPixel.BPP8,
           isReadOnly: true,
           sampling: FimTextureSampling.Nearest
-        }, dim)).toThrow();
+        })).toThrow();
       });
     });
 
     it('Prevents creation of oversized framebuffers', () => {
-      using(factory(canvasOptions, TestSizes.smallWide), canvas => {
+      using(factory(TestSizes.smallWide, canvasOptions), canvas => {
         const caps = canvas.detectCapabilities();
         const dim = FimDimensions.fromWidthHeight(caps.glMaxRenderBufferSize + 1, 10);
-        expect(() => canvas.createCoreTexture(textureOptions, dim)).toThrow();
+        expect(() => canvas.createCoreTexture(dim, textureOptions)).toThrow();
       });
     });
 

--- a/packages/fim-common-tests/src/ops/OpBrightnessContrast.ts
+++ b/packages/fim-common-tests/src/ops/OpBrightnessContrast.ts
@@ -19,10 +19,10 @@ export function fimTestSuiteOpBrightnessContrast(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const brightnessContrast = new FimOpBrightnessContrast(fim);
 
-        const input = fim.createImage();
+        const input = fim.createImage(TestSizes.smallWide);
         await input.fillSolidAsync(TestColors.grey);
 
-        const outputImage = fim.createImage();
+        const outputImage = fim.createImage(TestSizes.smallWide);
         await outputImage.executeAsync(brightnessContrast.$(input, 0.5, 0.0));
 
         expect(await outputImage.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.white);
@@ -33,10 +33,10 @@ export function fimTestSuiteOpBrightnessContrast(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const brightnessContrast = new FimOpBrightnessContrast(fim);
 
-        const input = fim.createImage();
+        const input = fim.createImage(TestSizes.smallWide);
         await input.fillSolidAsync('#d33');
 
-        const outputImage = fim.createImage();
+        const outputImage = fim.createImage(TestSizes.smallWide);
         await outputImage.executeAsync(brightnessContrast.$(input, 0.0, 0.5));
 
         expect(await outputImage.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);

--- a/packages/fim-common-tests/src/ops/OpBrightnessContrast.ts
+++ b/packages/fim-common-tests/src/ops/OpBrightnessContrast.ts
@@ -6,17 +6,17 @@ import { midpoint } from '../common/Globals';
 import { TestColors } from '../common/TestColors';
 import { TestSizes } from '../common/TestSizes';
 import { usingAsync } from '@leosingleton/commonlibs';
-import { Fim, FimDimensions, FimOpBrightnessContrast } from '@leosingleton/fim';
+import { Fim, FimOpBrightnessContrast } from '@leosingleton/fim';
 
 /** FimOpBrightnessContrast unit tests */
 export function fimTestSuiteOpBrightnessContrast(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FimOpBrightnessContrast - ${description}`, () => {
 
     it('Increases Brightness', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const brightnessContrast = new FimOpBrightnessContrast(fim);
 
         const input = fim.createImage(TestSizes.smallWide);
@@ -30,7 +30,7 @@ export function fimTestSuiteOpBrightnessContrast(
     });
 
     it('Increases Contrast', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const brightnessContrast = new FimOpBrightnessContrast(fim);
 
         const input = fim.createImage(TestSizes.smallWide);

--- a/packages/fim-common-tests/src/ops/OpBuiltin.ts
+++ b/packages/fim-common-tests/src/ops/OpBuiltin.ts
@@ -21,13 +21,13 @@ export function fimTestSuiteOpBuiltin(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const add = new FimOpAdd(fim);
 
-        const redImage = fim.createImage();
+        const redImage = fim.createImage(TestSizes.smallWide);
         await redImage.fillSolidAsync(TestColors.red);
 
-        const greenImage = fim.createImage();
+        const greenImage = fim.createImage(TestSizes.smallWide);
         await greenImage.fillSolidAsync(TestColors.green);
 
-        const outputImage = fim.createImage();
+        const outputImage = fim.createImage(TestSizes.smallWide);
         await outputImage.executeAsync(add.$(redImage, greenImage));
 
         expect(await outputImage.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.yellow);
@@ -38,13 +38,13 @@ export function fimTestSuiteOpBuiltin(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const alphaBlend = new FimOpAlphaBlend(fim);
 
-        const blackImage = fim.createImage();
+        const blackImage = fim.createImage(TestSizes.smallWide);
         await blackImage.fillSolidAsync(TestColors.black);
 
-        const whiteImage = fim.createImage();
+        const whiteImage = fim.createImage(TestSizes.smallWide);
         await whiteImage.fillSolidAsync(TestColors.white);
 
-        const outputImage = fim.createImage();
+        const outputImage = fim.createImage(TestSizes.smallWide);
         await outputImage.executeAsync(alphaBlend.$(blackImage, whiteImage, 0.5));
 
         const pixel = await outputImage.getPixelAsync(midpoint(TestSizes.smallWide));
@@ -58,7 +58,7 @@ export function fimTestSuiteOpBuiltin(
 
         const inputImage = await fim.createImageFromPngAsync(TestImages.fourSquaresPng());
 
-        const outputImage = fim.createImage();
+        const outputImage = fim.createImage(TestSizes.smallWide);
         await outputImage.executeAsync(copy.$(inputImage));
 
         await TestImages.expectFourSquaresPngAsync(outputImage);
@@ -69,13 +69,13 @@ export function fimTestSuiteOpBuiltin(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const darker = new FimOpDarker(fim);
 
-        const yellowImage = fim.createImage();
+        const yellowImage = fim.createImage(TestSizes.smallWide);
         await yellowImage.fillSolidAsync(TestColors.yellow);
 
-        const magentaImage = fim.createImage();
+        const magentaImage = fim.createImage(TestSizes.smallWide);
         await magentaImage.fillSolidAsync(TestColors.magenta);
 
-        const outputImage = fim.createImage();
+        const outputImage = fim.createImage(TestSizes.smallWide);
         await outputImage.executeAsync(darker.$(yellowImage, magentaImage));
 
         expect(await outputImage.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);
@@ -86,7 +86,7 @@ export function fimTestSuiteOpBuiltin(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const fill = new FimOpFill(fim);
 
-        const image = fim.createImage();
+        const image = fim.createImage(TestSizes.smallWide);
         await image.executeAsync(fill.$(TestColors.red));
 
         expect(await image.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);
@@ -97,10 +97,10 @@ export function fimTestSuiteOpBuiltin(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const invert = new FimOpInvert(fim);
 
-        const blueImage = fim.createImage();
+        const blueImage = fim.createImage(TestSizes.smallWide);
         await blueImage.fillSolidAsync(TestColors.blue);
 
-        const outputImage = fim.createImage();
+        const outputImage = fim.createImage(TestSizes.smallWide);
         await outputImage.executeAsync(invert.$(blueImage));
 
         expect(await outputImage.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.yellow);
@@ -111,10 +111,10 @@ export function fimTestSuiteOpBuiltin(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const unsharpMask = new FimOpUnsharpMask(fim);
 
-        const redImage = fim.createImage();
+        const redImage = fim.createImage(TestSizes.smallWide);
         await redImage.fillSolidAsync(TestColors.red);
 
-        const outputImage = fim.createImage();
+        const outputImage = fim.createImage(TestSizes.smallWide);
         await outputImage.executeAsync(unsharpMask.$(redImage, 0.25, 5));
 
         expect(await outputImage.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);
@@ -125,13 +125,13 @@ export function fimTestSuiteOpBuiltin(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const lighter = new FimOpLighter(fim);
 
-        const redImage = fim.createImage();
+        const redImage = fim.createImage(TestSizes.smallWide);
         await redImage.fillSolidAsync(TestColors.red);
 
-        const greenImage = fim.createImage();
+        const greenImage = fim.createImage(TestSizes.smallWide);
         await greenImage.fillSolidAsync(TestColors.green);
 
-        const outputImage = fim.createImage();
+        const outputImage = fim.createImage(TestSizes.smallWide);
         await outputImage.executeAsync(lighter.$(redImage, greenImage));
 
         expect(await outputImage.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.yellow);
@@ -142,13 +142,13 @@ export function fimTestSuiteOpBuiltin(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const subtract = new FimOpSubtract(fim);
 
-        const magentaImage = fim.createImage();
+        const magentaImage = fim.createImage(TestSizes.smallWide);
         await magentaImage.fillSolidAsync(TestColors.magenta);
 
-        const blueImage = fim.createImage();
+        const blueImage = fim.createImage(TestSizes.smallWide);
         await blueImage.fillSolidAsync(TestColors.blue);
 
-        const outputImage = fim.createImage();
+        const outputImage = fim.createImage(TestSizes.smallWide);
         await outputImage.executeAsync(subtract.$(magentaImage, blueImage));
 
         expect(await outputImage.getPixelAsync(midpoint(TestSizes.smallWide))).toEqual(TestColors.red);
@@ -159,10 +159,10 @@ export function fimTestSuiteOpBuiltin(
       await usingAsync(factory(TestSizes.smallWide), async fim => {
         const lighter = new FimOpLighter(fim);
 
-        const redImage = fim.createImage();
+        const redImage = fim.createImage(TestSizes.smallWide);
         await redImage.fillSolidAsync(TestColors.red);
 
-        const greenImage = fim.createImage();
+        const greenImage = fim.createImage(TestSizes.smallWide);
         await greenImage.fillSolidAsync(TestColors.green);
 
         await greenImage.executeAsync(lighter.$(redImage, greenImage));

--- a/packages/fim-common-tests/src/ops/OpBuiltin.ts
+++ b/packages/fim-common-tests/src/ops/OpBuiltin.ts
@@ -6,19 +6,19 @@ import { midpoint } from '../common/Globals';
 import { TestColors } from '../common/TestColors';
 import { TestSizes } from '../common/TestSizes';
 import { usingAsync } from '@leosingleton/commonlibs';
-import { Fim, FimDimensions, FimOpAdd, FimOpAlphaBlend, FimOpCopy, FimOpDarker, FimOpFill, FimOpInvert, FimOpLighter,
-  FimOpSubtract, FimOpUnsharpMask } from '@leosingleton/fim';
+import { Fim, FimOpAdd, FimOpAlphaBlend, FimOpCopy, FimOpDarker, FimOpFill, FimOpInvert, FimOpLighter, FimOpSubtract,
+  FimOpUnsharpMask } from '@leosingleton/fim';
 import { TestImages } from '../common/TestImages';
 
 /** Built-in operation tests for Fim */
 export function fimTestSuiteOpBuiltin(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`Fim built-in operations - ${description}`, () => {
 
     it('Add', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const add = new FimOpAdd(fim);
 
         const redImage = fim.createImage(TestSizes.smallWide);
@@ -35,7 +35,7 @@ export function fimTestSuiteOpBuiltin(
     });
 
     it('AlphaBlend', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const alphaBlend = new FimOpAlphaBlend(fim);
 
         const blackImage = fim.createImage(TestSizes.smallWide);
@@ -53,7 +53,7 @@ export function fimTestSuiteOpBuiltin(
     });
 
     it('Copy', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const copy = new FimOpCopy(fim);
 
         const inputImage = await fim.createImageFromPngAsync(TestImages.fourSquaresPng());
@@ -66,7 +66,7 @@ export function fimTestSuiteOpBuiltin(
     });
 
     it('Darker', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const darker = new FimOpDarker(fim);
 
         const yellowImage = fim.createImage(TestSizes.smallWide);
@@ -83,7 +83,7 @@ export function fimTestSuiteOpBuiltin(
     });
 
     it('Fill', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const fill = new FimOpFill(fim);
 
         const image = fim.createImage(TestSizes.smallWide);
@@ -94,7 +94,7 @@ export function fimTestSuiteOpBuiltin(
     });
 
     it('Invert', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const invert = new FimOpInvert(fim);
 
         const blueImage = fim.createImage(TestSizes.smallWide);
@@ -108,7 +108,7 @@ export function fimTestSuiteOpBuiltin(
     });
 
     it('UnsharpMask', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const unsharpMask = new FimOpUnsharpMask(fim);
 
         const redImage = fim.createImage(TestSizes.smallWide);
@@ -122,7 +122,7 @@ export function fimTestSuiteOpBuiltin(
     });
 
     it('Lighter', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const lighter = new FimOpLighter(fim);
 
         const redImage = fim.createImage(TestSizes.smallWide);
@@ -139,7 +139,7 @@ export function fimTestSuiteOpBuiltin(
     });
 
     it('Subtract', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const subtract = new FimOpSubtract(fim);
 
         const magentaImage = fim.createImage(TestSizes.smallWide);
@@ -156,7 +156,7 @@ export function fimTestSuiteOpBuiltin(
     });
 
     it('Supports the same image as an input and output', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const lighter = new FimOpLighter(fim);
 
         const redImage = fim.createImage(TestSizes.smallWide);

--- a/packages/fim-common-tests/src/ops/OpDownscale.ts
+++ b/packages/fim-common-tests/src/ops/OpDownscale.ts
@@ -54,12 +54,12 @@ async function testDownscale(
   const downscale = new FimOpDownscale(fim);
 
   // Draw the test pattern
-  const input = fim.createImage({}, inputDimensions);
+  const input = fim.createImage(inputDimensions);
   input.imageOptions.sampling = linear ? FimTextureSampling.Linear : FimTextureSampling.Nearest;
   await TestPatterns.renderAsync(input, TestPatterns.downscaleStress);
 
   // Run the downscale program
-  const output = fim.createImage({}, inputDimensions.rescale(1 / ratio));
+  const output = fim.createImage(inputDimensions.rescale(1 / ratio));
   await output.executeAsync(downscale.$(input));
 
   return output;

--- a/packages/fim-common-tests/src/ops/OpDownscale.ts
+++ b/packages/fim-common-tests/src/ops/OpDownscale.ts
@@ -72,8 +72,6 @@ async function testAndValidateDownscale(
   maxError = 0.05
 ): Promise<void> {
   await usingAsync(factory(), async fim => {
-    fim.engineOptions.maxImageDimensions = inputDimensions;
-
     // Run the downscale operation and sample a pixel in the center. It should be 50% grey.
     const output = await testDownscale(fim, ratio, inputDimensions);
     const color = await output.getPixelAsync(output.dim.getCenter());

--- a/packages/fim-common-tests/src/ops/OpDownscale.ts
+++ b/packages/fim-common-tests/src/ops/OpDownscale.ts
@@ -12,7 +12,7 @@ import { Fim, FimDimensions, FimImage, FimOpDownscale, FimTextureSampling, FimEr
 /** FimOpDownscale unit tests */
 export function fimTestSuiteOpDownscale(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FimOpDownscale - ${description}`, () => {
     it('Downscales at 4x', async () => testAndValidateDownscale(factory, 4));
@@ -27,7 +27,7 @@ export function fimTestSuiteOpDownscale(
     it('Downscales at 128x (wide)', async () => testAndValidateDownscale(factory, 128, TestSizes.mediumWide));
 
     it('Performs a copy at 1x', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         const output = await testDownscale(fim, 1, TestSizes.smallWide);
         await TestPatterns.validateAsync(output, TestPatterns.downscaleStress, true);
       });
@@ -38,7 +38,7 @@ export function fimTestSuiteOpDownscale(
     });
 
     it('Fails if input is non-linear', async () => {
-      await usingAsync(factory(TestSizes.smallWide), async fim => {
+      await usingAsync(factory(), async fim => {
         (await expectErrorAsync(testDownscale(fim, 1, TestSizes.smallWide, false))).toBeInstanceOf(FimError);
       });
     });
@@ -66,12 +66,14 @@ async function testDownscale(
 }
 
 async function testAndValidateDownscale(
-  factory: (maxImageDimensions: FimDimensions) => Fim,
+  factory: () => Fim,
   ratio: number,
   inputDimensions = FimDimensions.fromWidthHeight(256, 512),
   maxError = 0.05
 ): Promise<void> {
-  await usingAsync(factory(inputDimensions), async fim => {
+  await usingAsync(factory(), async fim => {
+    fim.engineOptions.maxImageDimensions = inputDimensions;
+
     // Run the downscale operation and sample a pixel in the center. It should be 50% grey.
     const output = await testDownscale(fim, ratio, inputDimensions);
     const color = await output.getPixelAsync(output.dim.getCenter());

--- a/packages/fim-common-tests/src/ops/OpGaussianBlur.ts
+++ b/packages/fim-common-tests/src/ops/OpGaussianBlur.ts
@@ -6,12 +6,12 @@ import { expectErrorAsync } from '../common/Async';
 import { midpoint } from '../common/Globals';
 import { TestSizes } from '../common/TestSizes';
 import { usingAsync } from '@leosingleton/commonlibs';
-import { Fim, FimColor, FimDimensions, FimError, FimOpGaussianBlur, FimTextureSampling } from '@leosingleton/fim';
+import { Fim, FimColor, FimError, FimOpGaussianBlur, FimTextureSampling } from '@leosingleton/fim';
 
 /** FimOpGaussianBlur unit tests */
 export function fimTestSuiteOpGaussianBlur(
   description: string,
-  factory: (maxImageDimensions: FimDimensions) => Fim
+  factory: () => Fim
 ): void {
   describe(`FimOpGaussianBlur - ${description}`, () => {
 
@@ -41,14 +41,14 @@ export function fimTestSuiteOpGaussianBlur(
 }
 
 async function testGaussianBlur(
-  factory: (maxImageDimensions: FimDimensions) => Fim,
+  factory: () => Fim,
   fast: boolean,
   inputSampling: FimTextureSampling,
   outputSampling: FimTextureSampling,
   sigma: number,
   kernelSize?: number
 ): Promise<void> {
-  await usingAsync(factory(TestSizes.mediumTall), async fim => {
+  await usingAsync(factory(), async fim => {
     const blur = new FimOpGaussianBlur(fim, fast);
 
     // Create a solid blue image of a specific shade

--- a/packages/fim-common-tests/src/ops/OpGaussianBlur.ts
+++ b/packages/fim-common-tests/src/ops/OpGaussianBlur.ts
@@ -53,11 +53,11 @@ async function testGaussianBlur(
 
     // Create a solid blue image of a specific shade
     const blueShade = FimColor.fromString('#21f');
-    const blueImage = fim.createImage({ sampling: inputSampling });
+    const blueImage = fim.createImage(TestSizes.mediumTall, { sampling: inputSampling });
     await blueImage.fillSolidAsync(blueShade);
 
     // Blur the image
-    const output = fim.createImage({ sampling: outputSampling });
+    const output = fim.createImage(TestSizes.mediumTall, { sampling: outputSampling });
     await output.executeAsync(blur.$(blueImage, sigma, kernelSize));
 
     // Ensure the output is still the same shade of blue--blurring shouldn't change the color

--- a/packages/fim-common-tests/src/suites/TestSuites.ts
+++ b/packages/fim-common-tests/src/suites/TestSuites.ts
@@ -40,7 +40,7 @@ export namespace TestSuites {
    */
   export function fim(
     description: string,
-    factory: (maxImageDimensions: FimDimensions) => Fim
+    factory: () => Fim
   ): void {
     // api/ tests
     fimTestSuiteCreateDispose(description, factory);

--- a/packages/fim-common-tests/src/suites/TestSuites.ts
+++ b/packages/fim-common-tests/src/suites/TestSuites.ts
@@ -12,6 +12,7 @@ import { fimTestSuiteOversized } from '../api/Oversized';
 import { fimTestSuitePngJpeg } from '../api/PngJpeg';
 import { fimTestSuiteResourceTracker } from '../api/ResourceTracker';
 import { fimTestSuiteWebGL } from '../api/WebGL';
+import { fimTestSuiteWebGLAutoscale } from '../api/WebGLAutoscale';
 import { fimTestSuiteWebGLContextLost } from '../api/WebGLContextLost';
 import { fimTestSuiteWebGLTransform } from '../api/WebGLTransform';
 import { coreCanvas2DTestSuiteCanvas } from '../core/CoreCanvas2D/Canvas';
@@ -48,6 +49,7 @@ export namespace TestSuites {
     fimTestSuiteCanvas(description, factory);
     fimTestSuitePngJpeg(description, factory);
     fimTestSuiteWebGL(description, factory);
+    fimTestSuiteWebGLAutoscale(description, factory);
     fimTestSuiteWebGLTransform(description, factory);
     fimTestSuiteWebGLContextLost(description, factory);
     fimTestSuiteOversized(description, factory);

--- a/packages/fim-common-tests/src/suites/TestSuites.ts
+++ b/packages/fim-common-tests/src/suites/TestSuites.ts
@@ -70,7 +70,7 @@ export namespace TestSuites {
    */
   export function coreCanvas2D(
     description: string,
-    factory: (canvasOptions: CoreCanvasOptions, dimensions: FimDimensions) => CoreCanvas2D
+    factory: (dimensions: FimDimensions, canvasOptions: CoreCanvasOptions) => CoreCanvas2D
   ): void {
     coreCanvas2DTestSuiteCreateDispose(description, factory);
     coreCanvas2DTestSuiteCanvas(description, factory);
@@ -84,7 +84,7 @@ export namespace TestSuites {
    */
   export function coreCanvasWebGL(
     description: string,
-    factory: (canvasOptions: CoreCanvasOptions, dimensions: FimDimensions) => CoreCanvasWebGL
+    factory: (dimensions: FimDimensions, canvasOptions: CoreCanvasOptions) => CoreCanvasWebGL
   ): void {
     coreCanvasWebGLTestSuiteCreateDispose(description, factory);
     coreCanvasWebGLTestSuiteCapabilities(description, factory);

--- a/packages/fim-node/src/__tests__/CommonSuites.node.ts
+++ b/packages/fim-node/src/__tests__/CommonSuites.node.ts
@@ -13,16 +13,16 @@ import { TestSuites } from '@leosingleton/fim-common-tests';
 const showTracing = false;
 const showWarnings = false;
 
-TestSuites.fim('FimNodeFactory (debug mode)', (maxImageDimensions) => {
-  const fim = FimNodeFactory.create(maxImageDimensions);
+TestSuites.fim('FimNodeFactory (debug mode)', () => {
+  const fim = FimNodeFactory.create();
   fim.engineOptions.debugMode = true;
   fim.engineOptions.showTracing = showTracing;
   fim.engineOptions.showWarnings = showWarnings;
   return fim;
 });
 
-TestSuites.fim('FimNodeFactory', (maxImageDimensions) => {
-  const fim = FimNodeFactory.create(maxImageDimensions);
+TestSuites.fim('FimNodeFactory', () => {
+  const fim = FimNodeFactory.create();
   fim.engineOptions.showTracing = showTracing;
   fim.engineOptions.showWarnings = showWarnings;
   return fim;

--- a/packages/fim-node/src/__tests__/CommonSuites.node.ts
+++ b/packages/fim-node/src/__tests__/CommonSuites.node.ts
@@ -35,7 +35,7 @@ engineOptions.showTracing = showTracing;
 engineOptions.showWarnings = showWarnings;
 
 TestSuites.coreCanvas2D('CoreNodeCanvas2D',
-  (canvasOptions, dimensions) => new CoreNodeCanvas2D(canvasOptions, dimensions, 'UnitTest', engineOptions));
+  (dimensions, canvasOptions) => new CoreNodeCanvas2D(dimensions, canvasOptions, 'UnitTest', engineOptions));
 
 TestSuites.coreCanvasWebGL('CoreNodeCanvasWebGL',
-  (canvasOptions, dimensions) => new CoreNodeCanvasWebGL(canvasOptions, dimensions, 'UnitTest', engineOptions));
+  (dimensions, canvasOptions) => new CoreNodeCanvasWebGL(dimensions, canvasOptions, 'UnitTest', engineOptions));

--- a/packages/fim-node/src/__tests__/ExportToCanvas.node.ts
+++ b/packages/fim-node/src/__tests__/ExportToCanvas.node.ts
@@ -75,7 +75,7 @@ describe('Exports to Canvas', () => {
       const dim = FimDimensions.fromWidthHeight(302, 298);
 
       // Create a FIM image and fill it with blue
-      const image = fim.createImage({}, dim);
+      const image = fim.createImage(dim);
       await image.fillSolidAsync(TestColors.blue);
 
       // Create an oversized canvas and fill with red

--- a/packages/fim-node/src/__tests__/ExportToCanvas.node.ts
+++ b/packages/fim-node/src/__tests__/ExportToCanvas.node.ts
@@ -46,7 +46,7 @@ function getPixel(context: CanvasRenderingContext2D, x: number, y: number): FimC
 describe('Exports to Canvas', () => {
 
   it('exportToCanvasAsync()', async () => {
-    await usingAsync(FimNodeFactory.create(TestSizes.mediumSquare), async fim => {
+    await usingAsync(FimNodeFactory.create(), async fim => {
       // Create a FIM image and fill it with blue
       const image = fim.createImage(TestSizes.mediumSquare);
       await image.fillSolidAsync(TestColors.blue);
@@ -71,7 +71,7 @@ describe('Exports to Canvas', () => {
   });
 
   it('exportToCanvasAsync() with downscale', async () => {
-    await usingAsync(FimNodeFactory.create(TestSizes.mediumSquare), async fim => {
+    await usingAsync(FimNodeFactory.create(), async fim => {
       const dim = FimDimensions.fromWidthHeight(302, 298);
 
       // Create a FIM image and fill it with blue

--- a/packages/fim-node/src/__tests__/ExportToCanvas.node.ts
+++ b/packages/fim-node/src/__tests__/ExportToCanvas.node.ts
@@ -48,7 +48,7 @@ describe('Exports to Canvas', () => {
   it('exportToCanvasAsync()', async () => {
     await usingAsync(FimNodeFactory.create(TestSizes.mediumSquare), async fim => {
       // Create a FIM image and fill it with blue
-      const image = fim.createImage();
+      const image = fim.createImage(TestSizes.mediumSquare);
       await image.fillSolidAsync(TestColors.blue);
 
       // Create a 100x100 canvas and fill with red

--- a/packages/fim-node/src/__tests__/PngJpeg.node.ts
+++ b/packages/fim-node/src/__tests__/PngJpeg.node.ts
@@ -35,7 +35,7 @@ describe('Loads from PNG and JPEG files', () => {
   it('loadFromPngFileAsync()', async () => {
     await usingAsync(FimNodeFactory.create(TestSizes.smallSquare), async fim => {
       // Load the four squares test pattern by URL
-      const image = fim.createImage();
+      const image = fim.createImage(TestSizes.smallSquare);
       await image.loadFromPngFileAsync(samplePng);
 
       // Validate the test pattern
@@ -46,7 +46,7 @@ describe('Loads from PNG and JPEG files', () => {
   it('loadFromJpegFileAsync()', async () => {
     await usingAsync(FimNodeFactory.create(TestSizes.smallSquare), async fim => {
       // Load the four squares test pattern by URL
-      const image = fim.createImage();
+      const image = fim.createImage(TestSizes.smallSquare);
       await image.loadFromJpegFileAsync(sampleJpeg);
 
       // Validate the test pattern

--- a/packages/fim-node/src/__tests__/PngJpeg.node.ts
+++ b/packages/fim-node/src/__tests__/PngJpeg.node.ts
@@ -13,7 +13,7 @@ const sampleJpeg = resolve(__dirname, 'sample-images/four-squares.jpg');
 describe('Loads from PNG and JPEG files', () => {
 
   it('createImageFromPngFileAsync()', async () => {
-    await usingAsync(FimNodeFactory.create(TestSizes.smallSquare), async fim => {
+    await usingAsync(FimNodeFactory.create(), async fim => {
       // Load the four squares test pattern by URL
       const image = await fim.createImageFromPngFileAsync(samplePng);
 
@@ -23,7 +23,7 @@ describe('Loads from PNG and JPEG files', () => {
   });
 
   it('createImageFromJpegFileAsync()', async () => {
-    await usingAsync(FimNodeFactory.create(TestSizes.smallSquare), async fim => {
+    await usingAsync(FimNodeFactory.create(), async fim => {
       // Load the four squares test pattern by URL
       const image = await fim.createImageFromJpegFileAsync(sampleJpeg);
 
@@ -33,7 +33,7 @@ describe('Loads from PNG and JPEG files', () => {
   });
 
   it('loadFromPngFileAsync()', async () => {
-    await usingAsync(FimNodeFactory.create(TestSizes.smallSquare), async fim => {
+    await usingAsync(FimNodeFactory.create(), async fim => {
       // Load the four squares test pattern by URL
       const image = fim.createImage(TestSizes.smallSquare);
       await image.loadFromPngFileAsync(samplePng);
@@ -44,7 +44,7 @@ describe('Loads from PNG and JPEG files', () => {
   });
 
   it('loadFromJpegFileAsync()', async () => {
-    await usingAsync(FimNodeFactory.create(TestSizes.smallSquare), async fim => {
+    await usingAsync(FimNodeFactory.create(), async fim => {
       // Load the four squares test pattern by URL
       const image = fim.createImage(TestSizes.smallSquare);
       await image.loadFromJpegFileAsync(sampleJpeg);

--- a/packages/fim-node/src/core/CoreNodeCanvas2D.ts
+++ b/packages/fim-node/src/core/CoreNodeCanvas2D.ts
@@ -12,9 +12,9 @@ import { Canvas, createCanvas } from 'canvas';
 
 /** Wrapper around the Node.js canvas library */
 export class CoreNodeCanvas2D extends CoreCanvas2D {
-  public constructor(canvasOptions: CoreCanvasOptions, dimensions: FimDimensions, handle: string,
+  public constructor(dimensions: FimDimensions, canvasOptions: CoreCanvasOptions, handle: string,
       engineOptions?: FimEngineOptions) {
-    super(loadFromFileAsync, canvasOptions, dimensions, handle, engineOptions);
+    super(loadFromFileAsync, dimensions, canvasOptions, handle, engineOptions);
 
     // Create the canvas using node-canvas
     this.canvasElement = createCanvas(dimensions.w, dimensions.h);
@@ -37,9 +37,9 @@ export class CoreNodeCanvas2D extends CoreCanvas2D {
     return this.canvasElement.getContext('2d');
   }
 
-  protected createCanvas2D(canvasOptions: CoreCanvasOptions, dimensions: FimDimensions, handle: string,
+  protected createCanvas2D(dimensions: FimDimensions, canvasOptions: CoreCanvasOptions, handle: string,
       engineOptions: FimEngineOptions): CoreCanvas2D {
-    return new CoreNodeCanvas2D(canvasOptions, dimensions, handle, engineOptions);
+    return new CoreNodeCanvas2D(dimensions, canvasOptions, handle, engineOptions);
   }
 
   protected async exportToFileAsync(type: CoreMimeType, quality?: number): Promise<Uint8Array> {

--- a/packages/fim-node/src/core/CoreNodeCanvasWebGL.ts
+++ b/packages/fim-node/src/core/CoreNodeCanvasWebGL.ts
@@ -11,9 +11,9 @@ import createContext from 'gl';
 
 /** Wrapper around the headless-gl WebGL library */
 export class CoreNodeCanvasWebGL extends CoreCanvasWebGL {
-  public constructor(canvasOptions: CoreCanvasOptions, dimensions: FimDimensions, handle: string,
+  public constructor(dimensions: FimDimensions, canvasOptions: CoreCanvasOptions, handle: string,
       engineOptions?: FimEngineOptions) {
-    super(canvasOptions, dimensions, handle, engineOptions);
+    super(dimensions, canvasOptions, handle, engineOptions);
 
     // Create the canvas using headless-gl
     this.glContext = createContext(dimensions.w, dimensions.h);
@@ -40,14 +40,14 @@ export class CoreNodeCanvasWebGL extends CoreCanvasWebGL {
     return this.glContext;
   }
 
-  protected createCanvas2D(canvasOptions: CoreCanvasOptions, dimensions: FimDimensions, handle: string,
+  protected createCanvas2D(dimensions: FimDimensions, canvasOptions: CoreCanvasOptions, handle: string,
       engineOptions: FimEngineOptions): CoreCanvas2D {
-    return new CoreNodeCanvas2D(canvasOptions, dimensions, handle, engineOptions);
+    return new CoreNodeCanvas2D(dimensions, canvasOptions, handle, engineOptions);
   }
 
-  protected createCoreTextureInternal(parent: CoreCanvasWebGL, options: CoreTextureOptions, dimensions: FimDimensions,
+  protected createCoreTextureInternal(parent: CoreCanvasWebGL, dimensions: FimDimensions, options: CoreTextureOptions,
       handle: string): CoreNodeTexture {
-    return new CoreNodeTexture(parent, options, dimensions, handle);
+    return new CoreNodeTexture(parent, dimensions, options, handle);
   }
 
   protected addCanvasEventListener(_type: string, _listener: EventListenerObject, _options: boolean): void {

--- a/packages/fim-node/src/core/FileReader.ts
+++ b/packages/fim-node/src/core/FileReader.ts
@@ -9,7 +9,7 @@ import { readFile } from 'fs';
  * @param path Path of the file to read
  * @returns File contents, as a `Uint8Array`
  */
-export async function fileReader(path: string): Promise<Uint8Array> {
+export async function fileReaderAsync(path: string): Promise<Uint8Array> {
   return new Promise((resolve, reject) => {
     readFile(path, (err, data) => {
       if (err) {

--- a/packages/fim-node/src/engine/NodeEngineFim.ts
+++ b/packages/fim-node/src/engine/NodeEngineFim.ts
@@ -6,7 +6,7 @@ import { NodeEngineImage } from './NodeEngineImage';
 import { FimNode } from '../api/FimNode';
 import { CoreNodeCanvas2D } from '../core/CoreNodeCanvas2D';
 import { CoreNodeCanvasWebGL } from '../core/CoreNodeCanvasWebGL';
-import { fileReader } from '../core/FileReader';
+import { fileReaderAsync } from '../core/FileReader';
 import { loadFromFileAsync } from '../core/ImageLoader';
 import { FimDimensions, FimImageOptions, FimObject } from '@leosingleton/fim';
 import { CoreCanvas2D, CoreCanvasOptions, CoreCanvasWebGL, EngineFimBase,
@@ -20,7 +20,7 @@ export class NodeEngineFim extends EngineFimBase<NodeEngineImage, EngineShader> 
    * @param name An optional name specified when creating the object to help with debugging
    */
   public constructor(name?: string) {
-    super(fileReader, loadFromFileAsync, name);
+    super(fileReaderAsync, loadFromFileAsync, name);
   }
 
   protected createEngineImage(parent: FimObject, dimensions: FimDimensions, options: FimImageOptions, name?: string):

--- a/packages/fim-node/src/engine/NodeEngineFim.ts
+++ b/packages/fim-node/src/engine/NodeEngineFim.ts
@@ -25,9 +25,9 @@ export class NodeEngineFim extends EngineFimBase<NodeEngineImage, EngineShader> 
     super(fileReader, loadFromFileAsync, maxImageDimensions, name);
   }
 
-  protected createEngineImage(parent: FimObject, options: FimImageOptions, dimensions: FimDimensions, name?: string):
+  protected createEngineImage(parent: FimObject, dimensions: FimDimensions, options: FimImageOptions, name?: string):
       NodeEngineImage {
-    return new NodeEngineImage(parent, options, dimensions, name);
+    return new NodeEngineImage(parent, dimensions, options, name);
   }
 
   protected createEngineGLShader(parent: FimObject, fragmentShader: GlslShader, vertexShader?: GlslShader,
@@ -35,11 +35,11 @@ export class NodeEngineFim extends EngineFimBase<NodeEngineImage, EngineShader> 
     return new EngineShader(parent, fragmentShader, vertexShader, name);
   }
 
-  public createCoreCanvas2D(options: CoreCanvasOptions, dimensions: FimDimensions, handle: string): CoreCanvas2D {
-    return new CoreNodeCanvas2D(options, dimensions, handle, this.engineOptions);
+  public createCoreCanvas2D(dimensions: FimDimensions, options: CoreCanvasOptions, handle: string): CoreCanvas2D {
+    return new CoreNodeCanvas2D(dimensions, options, handle, this.engineOptions);
   }
 
-  public createCoreCanvasWebGL(options: CoreCanvasOptions, dimensions: FimDimensions, handle: string): CoreCanvasWebGL {
-    return new CoreNodeCanvasWebGL(options, dimensions, handle, this.engineOptions);
+  public createCoreCanvasWebGL(dimensions: FimDimensions, options: CoreCanvasOptions, handle: string): CoreCanvasWebGL {
+    return new CoreNodeCanvasWebGL(dimensions, options, handle, this.engineOptions);
   }
 }

--- a/packages/fim-node/src/engine/NodeEngineFim.ts
+++ b/packages/fim-node/src/engine/NodeEngineFim.ts
@@ -17,12 +17,10 @@ import { GlslShader } from 'webpack-glsl-minify';
 export class NodeEngineFim extends EngineFimBase<NodeEngineImage, EngineShader> implements FimNode {
   /**
    * Constructor
-   * @param maxImageDimensions Maximum dimensions of any image. If unspecified, defaults to the maximum image size
-   *    supported by the WebGL capabilities of the browser and GPU.
    * @param name An optional name specified when creating the object to help with debugging
    */
-  public constructor(maxImageDimensions?: FimDimensions, name?: string) {
-    super(fileReader, loadFromFileAsync, maxImageDimensions, name);
+  public constructor(name?: string) {
+    super(fileReader, loadFromFileAsync, name);
   }
 
   protected createEngineImage(parent: FimObject, dimensions: FimDimensions, options: FimImageOptions, name?: string):

--- a/packages/fim-node/src/engine/__tests__/NodeEngineFim.node.ts
+++ b/packages/fim-node/src/engine/__tests__/NodeEngineFim.node.ts
@@ -3,12 +3,12 @@
 // See LICENSE in the project root for license information.
 
 import { NodeEngineFim } from '../NodeEngineFim';
-import { FimDimensions, FimReleaseResourcesFlags } from '@leosingleton/fim';
+import { FimReleaseResourcesFlags } from '@leosingleton/fim';
 
 describe('NodeEngineFim', () => {
 
   it('Creates, releases, and disposes', () => {
-    const eng = new NodeEngineFim(FimDimensions.fromWidthHeight(100, 100));
+    const eng = new NodeEngineFim();
     eng.releaseResources(FimReleaseResourcesFlags.All);
     eng.dispose();
   });

--- a/packages/fim-node/src/factory/FimNodeFactory.ts
+++ b/packages/fim-node/src/factory/FimNodeFactory.ts
@@ -4,16 +4,14 @@
 
 import { FimNode } from '../api/FimNode';
 import { NodeEngineFim } from '../engine/NodeEngineFim';
-import { FimDimensions } from '@leosingleton/fim';
 
+/** Factory methods for instantiating the FIM library in Node.js */
 export namespace FimNodeFactory {
   /**
    * Creates an instance of the FimNode interface
-   * @param maxImageDimensions Maximum dimensions of any image. If unspecified, defaults to the maximum image size
-   *    supported by the WebGL capabilities of the browser and GPU.
    * @param name An optional name specified when creating the object to help with debugging
    */
-  export function create(maxImageDimensions?: FimDimensions, name?: string): FimNode {
-    return new NodeEngineFim(maxImageDimensions, name);
+  export function create(name?: string): FimNode {
+    return new NodeEngineFim(name);
   }
 }

--- a/packages/fim/src/api/Fim.ts
+++ b/packages/fim/src/api/Fim.ts
@@ -70,12 +70,12 @@ export interface FimBase<TImage extends FimImage, TShader extends FimShader> ext
 
   /**
    * Creates a new image
-   * @param dimensions Optional image dimensions. If unspecified, defaults to the dimensions of the FIM instance.
+   * @param dimensions Image dimensions
    * @param options Optional overrides to the image options from the parent Fim object
    * @param name Optional name specified when creating the object to help with debugging
    * @param parent Optional parent object. If unspecified, defaults to the root FIM instance.
    */
-  createImage(dimensions?: FimDimensions, options?: FimImageOptions, name?: string, parent?: FimObject): TImage;
+  createImage(dimensions: FimDimensions, options?: FimImageOptions, name?: string, parent?: FimObject): TImage;
 
   /**
    * Creates a new image from a PNG file

--- a/packages/fim/src/api/Fim.ts
+++ b/packages/fim/src/api/Fim.ts
@@ -20,9 +20,6 @@ export type Fim = FimBase<FimImage, FimShader>;
 
 /** Templated version of the `Fim` interface which supports specific implementations of image and shader classes */
 export interface FimBase<TImage extends FimImage, TShader extends FimShader> extends FimObject {
-  /** Maximum dimensions of any image */
-  readonly maxImageDimensions: FimDimensions;
-
   /**
    * Options for the FIM execution engine
    *

--- a/packages/fim/src/api/Fim.ts
+++ b/packages/fim/src/api/Fim.ts
@@ -70,12 +70,12 @@ export interface FimBase<TImage extends FimImage, TShader extends FimShader> ext
 
   /**
    * Creates a new image
-   * @param options Optional overrides to the image options from the parent Fim object
    * @param dimensions Optional image dimensions. If unspecified, defaults to the dimensions of the FIM instance.
+   * @param options Optional overrides to the image options from the parent Fim object
    * @param name Optional name specified when creating the object to help with debugging
    * @param parent Optional parent object. If unspecified, defaults to the root FIM instance.
    */
-  createImage(options?: FimImageOptions, dimensions?: FimDimensions, name?: string, parent?: FimObject): TImage;
+  createImage(dimensions?: FimDimensions, options?: FimImageOptions, name?: string, parent?: FimObject): TImage;
 
   /**
    * Creates a new image from a PNG file

--- a/packages/fim/src/api/FimEngineOptions.ts
+++ b/packages/fim/src/api/FimEngineOptions.ts
@@ -3,11 +3,18 @@
 // See LICENSE in the project root for license information.
 
 import { FimExecutionStrategy } from './FimExecutionStrategy';
+import { FimDimensions } from '../primitives/FimDimensions';
 
 /** Options for the FIM execution engine */
 export interface FimEngineOptions {
   /** Execution strategy (space vs. time) */
   executionStrategy: FimExecutionStrategy;
+
+  /**
+   * Maximum dimensions of any image. Defaults to the maximum image size supported by the WebGL capabilities of the
+   * browser and GPU.
+   */
+  maxImageDimensions: FimDimensions;
 
   /** Maximum canvas memory to use, in bytes. 0 for no limit. */
   maxCanvasMemory: number;
@@ -65,6 +72,7 @@ export interface FimEngineOptions {
  */
 export const defaultEngineOptions: FimEngineOptions = {
   executionStrategy: FimExecutionStrategy.MaximizeSpeed,
+  maxImageDimensions: FimDimensions.fromSquareDimension(1),
   maxCanvasMemory: 0,
   maxGLMemory: 0,
   shaderInstanceLimit: 4,

--- a/packages/fim/src/core/CoreCallbackCollection.ts
+++ b/packages/fim/src/core/CoreCallbackCollection.ts
@@ -1,0 +1,35 @@
+// FIM - Fast Image Manipulation Library for Javascript
+// Copyright (c) Leo C. Singleton IV <leo@leosingleton.com>
+// See LICENSE in the project root for license information.
+
+import { UnhandledError } from '@leosingleton/commonlibs';
+
+/** Helper class to register and invoke callback functions */
+export class CoreCallbackCollection {
+  /**
+   * Registers a callback to invoke in `invokeCallbacks()`
+   * @param callback Callback to invoke
+   */
+  public registerCallback(callback: () => void): void {
+    this.callbacks.push(callback);
+  }
+
+  /** Invokes all registered callback functions */
+  public invokeCallbacks(): void {
+    for (const callback of this.callbacks) {
+      try {
+        callback();
+      } catch (err) {
+        UnhandledError.reportError(err);
+      }
+    }
+  }
+
+  /** Removes all registered callback functions */
+  public removeAllCallbacks(): void {
+    this.callbacks = [];
+  }
+
+  /** Registered callback functions */
+  private callbacks: (() => void)[] = [];
+}

--- a/packages/fim/src/core/CoreCanvas.ts
+++ b/packages/fim/src/core/CoreCanvas.ts
@@ -17,12 +17,12 @@ import { deepCopy } from '@leosingleton/commonlibs';
 export abstract class CoreCanvas implements FimDimensional {
   /**
    * Derived classes must override this constructor to instantiate the canvasElement object
-   * @param canvasOptions Canvas options
    * @param dimensions Canvas dimensions
+   * @param canvasOptions Canvas options
    * @param handle Handle of the image that owns this canvas. Used only for debugging.
    * @param engineOptions Options for the FIM execution engine
    */
-  protected constructor(canvasOptions: CoreCanvasOptions, dimensions: FimDimensions, handle: string,
+  protected constructor(dimensions: FimDimensions, canvasOptions: CoreCanvasOptions, handle: string,
       engineOptions?: FimEngineOptions) {
     this.dim = dimensions.toFloor();
     this.handle = handle;
@@ -85,13 +85,13 @@ export abstract class CoreCanvas implements FimDimensional {
    * @returns `CoreCanvas2D` instance of the same type as this canvas. The caller is reponsible for calling `dispose()`
    *    on the returned object.
    */
-  public createTemporaryCanvas2D(canvasOptions?: CoreCanvasOptions, dimensions?: FimDimensions): CoreCanvas2D {
-    return this.createCanvas2D(canvasOptions ?? this.canvasOptions, dimensions ?? this.dim, `${this.handle}/Temp`,
+  public createTemporaryCanvas2D(dimensions?: FimDimensions, canvasOptions?: CoreCanvasOptions): CoreCanvas2D {
+    return this.createCanvas2D(dimensions ?? this.dim, canvasOptions ?? this.canvasOptions, `${this.handle}/Temp`,
       this.engineOptions);
   }
 
   /** Derived classes must implement this method to call the CoreCanvas2D constructor */
-  protected abstract createCanvas2D(canvasOptions: CoreCanvasOptions, dimensions: FimDimensions, handle: string,
+  protected abstract createCanvas2D(dimensions: FimDimensions, canvasOptions: CoreCanvasOptions, handle: string,
     engineOptions: FimEngineOptions): CoreCanvas2D;
 
   /**

--- a/packages/fim/src/core/CoreCanvas2D.ts
+++ b/packages/fim/src/core/CoreCanvas2D.ts
@@ -20,14 +20,14 @@ import { DisposableSet, IDisposable, makeDisposable, using, usingAsync } from '@
 export abstract class CoreCanvas2D extends CoreCanvas {
   /**
    * @param imageLoader `CoreImageLoader` implementation for reading and writing to and from PNG and JPEG formats
-   * @param canvasOptions Canvas options
    * @param dimensions Canvas dimensions
+   * @param canvasOptions Canvas options
    * @param handle Handle of the image that owns this canvas. Used only for debugging.
    * @param engineOptions Options for the FIM execution engine
    */
-  protected constructor(private readonly imageLoader: CoreImageLoader, canvasOptions: CoreCanvasOptions,
-      dimensions: FimDimensions, handle: string, engineOptions?: FimEngineOptions) {
-    super(canvasOptions, dimensions, handle, engineOptions);
+  protected constructor(private readonly imageLoader: CoreImageLoader, dimensions: FimDimensions,
+      canvasOptions: CoreCanvasOptions, handle: string, engineOptions?: FimEngineOptions) {
+    super(dimensions, canvasOptions, handle, engineOptions);
   }
 
   /** Returns the 2D rendering context for the canvas */
@@ -167,7 +167,7 @@ export abstract class CoreCanvas2D extends CoreCanvas {
       });
     } else {
       // Really slow case: Cropping or rescaling is required. Render to a temporary canvas, then copy.
-      await usingAsync(me.createTemporaryCanvas2D({ downscale: 1 }, dimensions), async temp => {
+      await usingAsync(me.createTemporaryCanvas2D(dimensions, { downscale: 1 }), async temp => {
         await temp.loadPixelDataAsync(pixelData, dimensions);
         await me.copyFromAsync(temp);
       });

--- a/packages/fim/src/core/CoreCanvas2D.ts
+++ b/packages/fim/src/core/CoreCanvas2D.ts
@@ -19,13 +19,13 @@ import { DisposableSet, IDisposable, makeDisposable, using, usingAsync } from '@
 /** Wrapper around the HTML canvas and canvas-like objects */
 export abstract class CoreCanvas2D extends CoreCanvas {
   /**
-   * @param imageLoader `CoreImageLoader` implementation for reading and writing to and from PNG and JPEG formats
+   * @param imageLoaderAsync `CoreImageLoader` implementation for reading and writing to and from PNG and JPEG formats
    * @param dimensions Canvas dimensions
    * @param canvasOptions Canvas options
    * @param handle Handle of the image that owns this canvas. Used only for debugging.
    * @param engineOptions Options for the FIM execution engine
    */
-  protected constructor(private readonly imageLoader: CoreImageLoader, dimensions: FimDimensions,
+  protected constructor(private readonly imageLoaderAsync: CoreImageLoader, dimensions: FimDimensions,
       canvasOptions: CoreCanvasOptions, handle: string, engineOptions?: FimEngineOptions) {
     super(dimensions, canvasOptions, handle, engineOptions);
   }
@@ -202,7 +202,7 @@ export abstract class CoreCanvas2D extends CoreCanvas {
    * @param pngFile PNG file, as a Uint8Array
    */
   public loadFromPngAsync(pngFile: Uint8Array): Promise<void> {
-    return this.imageLoader(pngFile, CoreMimeType.PNG, image => this.loadFromImage(image));
+    return this.imageLoaderAsync(pngFile, CoreMimeType.PNG, async image => this.loadFromImage(image));
   }
 
   /**
@@ -210,7 +210,7 @@ export abstract class CoreCanvas2D extends CoreCanvas {
    * @param jpegFile JPEG file, as a Uint8Array
    */
   public loadFromJpegAsync(jpegFile: Uint8Array): Promise<void> {
-    return this.imageLoader(jpegFile, CoreMimeType.JPEG, image => this.loadFromImage(image));
+    return this.imageLoaderAsync(jpegFile, CoreMimeType.JPEG, async image => this.loadFromImage(image));
   }
 
   /**

--- a/packages/fim/src/core/CoreCanvas2D.ts
+++ b/packages/fim/src/core/CoreCanvas2D.ts
@@ -19,13 +19,13 @@ import { DisposableSet, IDisposable, makeDisposable, using, usingAsync } from '@
 /** Wrapper around the HTML canvas and canvas-like objects */
 export abstract class CoreCanvas2D extends CoreCanvas {
   /**
-   * @param imageLoaderAsync `CoreImageLoader` implementation for reading and writing to and from PNG and JPEG formats
+   * @param imageLoader `CoreImageLoader` implementation for reading and writing to and from PNG and JPEG formats
    * @param dimensions Canvas dimensions
    * @param canvasOptions Canvas options
    * @param handle Handle of the image that owns this canvas. Used only for debugging.
    * @param engineOptions Options for the FIM execution engine
    */
-  protected constructor(private readonly imageLoaderAsync: CoreImageLoader, dimensions: FimDimensions,
+  protected constructor(private readonly imageLoader: CoreImageLoader, dimensions: FimDimensions,
       canvasOptions: CoreCanvasOptions, handle: string, engineOptions?: FimEngineOptions) {
     super(dimensions, canvasOptions, handle, engineOptions);
   }
@@ -202,7 +202,7 @@ export abstract class CoreCanvas2D extends CoreCanvas {
    * @param pngFile PNG file, as a Uint8Array
    */
   public loadFromPngAsync(pngFile: Uint8Array): Promise<void> {
-    return this.imageLoaderAsync(pngFile, CoreMimeType.PNG, async image => this.loadFromImage(image));
+    return this.imageLoader(pngFile, CoreMimeType.PNG, image => this.loadFromImage(image));
   }
 
   /**
@@ -210,7 +210,7 @@ export abstract class CoreCanvas2D extends CoreCanvas {
    * @param jpegFile JPEG file, as a Uint8Array
    */
   public loadFromJpegAsync(jpegFile: Uint8Array): Promise<void> {
-    return this.imageLoaderAsync(jpegFile, CoreMimeType.JPEG, async image => this.loadFromImage(image));
+    return this.imageLoader(jpegFile, CoreMimeType.JPEG, image => this.loadFromImage(image));
   }
 
   /**

--- a/packages/fim/src/core/CoreCanvasWebGL.ts
+++ b/packages/fim/src/core/CoreCanvasWebGL.ts
@@ -446,20 +446,20 @@ export abstract class CoreCanvasWebGL extends CoreCanvas {
 
   /**
    * Calls the CoreTexture constructor
+   * @param dimensions Texture dimensions
    * @param options Texture options
-   * @param dimensions Optional texture dimensions. Defaults to the size of this canvas.
    * @param handle Optional texture handle, for debugging
    */
-  public createCoreTexture(options: CoreTextureOptions, dimensions?: FimDimensions, handle?: string): CoreTexture {
+  public createCoreTexture(dimensions: FimDimensions, options: CoreTextureOptions, handle?: string): CoreTexture {
     const me = this;
     me.ensureNotDisposed();
 
-    return me.createCoreTextureInternal(me, options, dimensions ?? me.dim, handle ?? `${me.handle}/Texture`);
+    return me.createCoreTextureInternal(me, dimensions, options, handle ?? `${me.handle}/Texture`);
   }
 
   /** Derived classes must implement this method to call the `CoreCanvas2D` constructor */
-  protected abstract createCoreTextureInternal(parent: CoreCanvasWebGL, options: FimImageOptions,
-    dimensions: FimDimensions, handle: string): CoreTexture;
+  protected abstract createCoreTextureInternal(parent: CoreCanvasWebGL, dimensions: FimDimensions,
+    options: FimImageOptions, handle: string): CoreTexture;
 
   public fillSolid(color: FimColor | string): void {
     const me = this;

--- a/packages/fim/src/core/CoreImageLoader.ts
+++ b/packages/fim/src/core/CoreImageLoader.ts
@@ -9,7 +9,7 @@ import { ImageSource } from './types/ImageSource';
  * Loads a file's contents onto an `ImageSource` instance which can then be loaded onto a canvas
  * @param file Image file, as a Uint8Array
  * @param type Mime type of the image file to load
- * @param callback Callback to execute once the image contents are loaded
+ * @param callbackAsync Callback to execute once the image contents are loaded
  */
-export type CoreImageLoader = (file: Uint8Array, type: CoreMimeType, callback: (image: ImageSource) => void)
-  => Promise<void>;
+export type CoreImageLoader = (file: Uint8Array, type: CoreMimeType,
+  callbackAsync: (image: ImageSource) => Promise<void>) => Promise<void>;

--- a/packages/fim/src/core/CoreImageLoader.ts
+++ b/packages/fim/src/core/CoreImageLoader.ts
@@ -9,7 +9,7 @@ import { ImageSource } from './types/ImageSource';
  * Loads a file's contents onto an `ImageSource` instance which can then be loaded onto a canvas
  * @param file Image file, as a Uint8Array
  * @param type Mime type of the image file to load
- * @param callbackAsync Callback to execute once the image contents are loaded
+ * @param callback Callback to execute once the image contents are loaded
  */
-export type CoreImageLoader = (file: Uint8Array, type: CoreMimeType,
-  callbackAsync: (image: ImageSource) => Promise<void>) => Promise<void>;
+export type CoreImageLoader = (file: Uint8Array, type: CoreMimeType, callback: (image: ImageSource) => void)
+  => Promise<void>;

--- a/packages/fim/src/core/CoreTexture.ts
+++ b/packages/fim/src/core/CoreTexture.ts
@@ -19,14 +19,14 @@ export abstract class CoreTexture extends CoreWebGLObject implements FimDimensio
   /**
    * Constructor
    * @param parent The parent WebGL canvas
-   * @param options Texture options
    * @param dimensions Texture dimensions
+   * @param options Texture options
    * @param handle Texture handle, for debugging
    */
-  public constructor(parent: CoreCanvasWebGL, options: CoreTextureOptions, dimensions: FimDimensions, handle: string) {
+  public constructor(parent: CoreCanvasWebGL, dimensions: FimDimensions, options: CoreTextureOptions, handle: string) {
     super(parent, handle);
-    this.textureOptions = deepCopy(options);
     this.dim = dimensions.toFloor();
+    this.textureOptions = deepCopy(options);
 
     // Ensure the dimensions do not exceed WebGL's maximum texture size
     const caps = parent.detectCapabilities();
@@ -213,7 +213,7 @@ export abstract class CoreTexture extends CoreWebGLObject implements FimDimensio
     const maxDimension = me.parentCanvas.detectCapabilities().glMaxTextureSize;
     if (srcCanvas.dim.w > maxDimension || srcCanvas.dim.h > maxDimension) {
       // Slow path: first copy the source canvas to a smaller canvas
-      await usingAsync(srcCanvas.createTemporaryCanvas2D({ downscale: 1 }, me.dim), async temp => {
+      await usingAsync(srcCanvas.createTemporaryCanvas2D(me.dim, { downscale: 1 }), async temp => {
         await temp.copyFromAsync(srcCanvas);
         await me.copyFromAsync(temp);
       });

--- a/packages/fim/src/engine/EngineFim.ts
+++ b/packages/fim/src/engine/EngineFim.ts
@@ -280,10 +280,10 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
     return this.resources.metrics;
   }
 
-  public createImage(dimensions?: FimDimensions, options?: FimImageOptions, name?: string, parent?: FimObject):
+  public createImage(dimensions: FimDimensions, options?: FimImageOptions, name?: string, parent?: FimObject):
       TEngineImage {
     this.ensureNotDisposed();
-    return this.createEngineImage(parent ?? this, dimensions ?? this.maxImageDimensions, options ?? {}, name);
+    return this.createEngineImage(parent ?? this, dimensions, options ?? {}, name);
   }
 
   public createImageFromPngAsync(pngFile: Uint8Array, options?: FimImageOptions, name?: string, parent?: FimObject):

--- a/packages/fim/src/engine/EngineFim.ts
+++ b/packages/fim/src/engine/EngineFim.ts
@@ -37,10 +37,10 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
   /**
    * Constructor
    * @param fileReader `CoreFileReader` implementation for reading or downloading binary files
-   * @param imageLoaderAsync `CoreImageLoader` implementation for reading and writing to and from PNG and JPEG formats
+   * @param imageLoader `CoreImageLoader` implementation for reading and writing to and from PNG and JPEG formats
    * @param name An optional name specified when creating the object to help with debugging
    */
-  public constructor(public readonly fileReader: CoreFileReader, public readonly imageLoaderAsync: CoreImageLoader,
+  public constructor(public readonly fileReader: CoreFileReader, public readonly imageLoader: CoreImageLoader,
       name?: string) {
     super(EngineObjectType.Fim, name);
     this.resources = new ResourceTracker(this);
@@ -150,7 +150,7 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
   }
 
   /** Returns the WebGL canvas for running shaders. Creates the canvas on first use. */
-  public async getWebGLCanvas(_dimensions: FimDimensions): Promise<CoreCanvasWebGL> {
+  public getWebGLCanvas(): CoreCanvasWebGL {
     const me = this;
 
     // The WebGL canvas is created on first use and may be disposed prematurely via releaseResources(). If it is already
@@ -304,9 +304,9 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
     me.ensureNotDisposed();
 
     let result: TEngineImage;
-    await me.imageLoaderAsync(file, type, image => {
+    await me.imageLoader(file, type, image => {
       result = me.createEngineImage(parent ?? this, FimDimensions.fromObject(image), options ?? {}, name);
-      return result.loadFromImageAsync(image);
+      result.loadFromImage(image);
     });
 
     return result;

--- a/packages/fim/src/engine/EngineFim.ts
+++ b/packages/fim/src/engine/EngineFim.ts
@@ -77,7 +77,7 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
       glTextureDepthsLinear: [],
       glTextureDepthsNearest: []
     };
-    const tinyCanvas = this.createCoreCanvasWebGL({}, FimDimensions.fromSquareDimension(1),
+    const tinyCanvas = this.createCoreCanvasWebGL(FimDimensions.fromSquareDimension(1), {},
       `${this.handle}/DetectCapabilities`);
     try {
       const glCapabilities = tinyCanvas.detectCapabilities();
@@ -180,7 +180,7 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
     // the requested resolution.
     const glDimensions = me.maxImageDimensions.fitInsideSquare(maxDimension).toFloor();
     me.optimizer.reserveCanvasMemory(glDimensions.getArea() * 4);
-    const glCanvas = me.glCanvas = me.createCoreCanvasWebGL(me.getGLCanvasOptions(), glDimensions,
+    const glCanvas = me.glCanvas = me.createCoreCanvasWebGL(glDimensions, me.getGLCanvasOptions(),
       `${me.handle}/WebGLCanvas`);
 
     // Register context lost handler and restored handlers. On context lost, we must free all textures and shaders. They
@@ -280,10 +280,10 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
     return this.resources.metrics;
   }
 
-  public createImage(options?: FimImageOptions, dimensions?: FimDimensions, name?: string, parent?: FimObject):
+  public createImage(dimensions?: FimDimensions, options?: FimImageOptions, name?: string, parent?: FimObject):
       TEngineImage {
     this.ensureNotDisposed();
-    return this.createEngineImage(parent ?? this, options ?? {}, dimensions ?? this.maxImageDimensions, name);
+    return this.createEngineImage(parent ?? this, dimensions ?? this.maxImageDimensions, options ?? {}, name);
   }
 
   public createImageFromPngAsync(pngFile: Uint8Array, options?: FimImageOptions, name?: string, parent?: FimObject):
@@ -304,7 +304,7 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
 
     let result: TEngineImage;
     await me.imageLoader(file, type, image => {
-      result = me.createEngineImage(parent ?? this, options ?? {}, FimDimensions.fromObject(image), name);
+      result = me.createEngineImage(parent ?? this, FimDimensions.fromObject(image), options ?? {}, name);
       result.loadFromImage(image);
     });
 
@@ -330,7 +330,7 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
   }
 
   /** Derived classes must implement this method to call the TEngineImage constructor */
-  protected abstract createEngineImage(parent: FimObject, options: FimImageOptions, dimensions: FimDimensions,
+  protected abstract createEngineImage(parent: FimObject, dimensions: FimDimensions, options: FimImageOptions,
     name?: string): TEngineImage;
 
   /** Derived classes must implement this method to call the TEngineShader constructor */
@@ -338,10 +338,10 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
     name?: string): TEngineShader;
 
   /** Derived classes must implement this method to call the CoreCanvas2D constructor */
-  public abstract createCoreCanvas2D(options: CoreCanvasOptions, dimensions: FimDimensions, handle: string):
+  public abstract createCoreCanvas2D(dimensions: FimDimensions, options: CoreCanvasOptions, handle: string):
     CoreCanvas2D;
 
   /** Derived classes must implement this method to call the CoreCanvasWebGL constructor */
-  public abstract createCoreCanvasWebGL(options: CoreCanvasOptions, dimensions: FimDimensions, handle: string):
+  public abstract createCoreCanvasWebGL(dimensions: FimDimensions, options: CoreCanvasOptions, handle: string):
     CoreCanvasWebGL;
 }

--- a/packages/fim/src/engine/EngineFim.ts
+++ b/packages/fim/src/engine/EngineFim.ts
@@ -96,12 +96,8 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
     engineOptions.maxGLTextureSize = capabilities.glMaxTextureSize;
 
     // Set the maximum image dimensions to the specified value. If unspecified, default to the WebGL capabilities.
-    //const maxDimension = Math.min(capabilities.glMaxRenderBufferSize, capabilities.glMaxTextureSize);
-    //engineOptions.maxImageDimensions = FimDimensions.fromSquareDimension(maxDimension);
-
-    // TODO: Enable the two lines of code above once we have auto-resizing of the WebGL canvas. For now, it's just too
-    // slow to execute every single unit test at the GPU's maximum resolution, so we hardcode the limit to 640x480 here.
-    engineOptions.maxImageDimensions = FimDimensions.fromWidthHeight(640, 480);
+    const maxDimension = Math.min(capabilities.glMaxRenderBufferSize, capabilities.glMaxTextureSize);
+    engineOptions.maxImageDimensions = FimDimensions.fromSquareDimension(maxDimension);
   }
 
   public readonly engineOptions: FimEngineOptions;

--- a/packages/fim/src/engine/EngineFim.ts
+++ b/packages/fim/src/engine/EngineFim.ts
@@ -37,10 +37,10 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
   /**
    * Constructor
    * @param fileReader `CoreFileReader` implementation for reading or downloading binary files
-   * @param imageLoader `CoreImageLoader` implementation for reading and writing to and from PNG and JPEG formats
+   * @param imageLoaderAsync `CoreImageLoader` implementation for reading and writing to and from PNG and JPEG formats
    * @param name An optional name specified when creating the object to help with debugging
    */
-  public constructor(public readonly fileReader: CoreFileReader, public readonly imageLoader: CoreImageLoader,
+  public constructor(public readonly fileReader: CoreFileReader, public readonly imageLoaderAsync: CoreImageLoader,
       name?: string) {
     super(EngineObjectType.Fim, name);
     this.resources = new ResourceTracker(this);
@@ -150,7 +150,7 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
   }
 
   /** Returns the WebGL canvas for running shaders. Creates the canvas on first use. */
-  public getWebGLCanvas(): CoreCanvasWebGL {
+  public async getWebGLCanvas(_dimensions: FimDimensions): Promise<CoreCanvasWebGL> {
     const me = this;
 
     // The WebGL canvas is created on first use and may be disposed prematurely via releaseResources(). If it is already
@@ -304,9 +304,9 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
     me.ensureNotDisposed();
 
     let result: TEngineImage;
-    await me.imageLoader(file, type, image => {
+    await me.imageLoaderAsync(file, type, image => {
       result = me.createEngineImage(parent ?? this, FimDimensions.fromObject(image), options ?? {}, name);
-      result.loadFromImage(image);
+      return result.loadFromImageAsync(image);
     });
 
     return result;

--- a/packages/fim/src/engine/EngineFim.ts
+++ b/packages/fim/src/engine/EngineFim.ts
@@ -36,11 +36,11 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
     extends EngineObject implements FimBase<TEngineImage, TEngineShader> {
   /**
    * Constructor
-   * @param fileReader `CoreFileReader` implementation for reading or downloading binary files
-   * @param imageLoader `CoreImageLoader` implementation for reading and writing to and from PNG and JPEG formats
+   * @param fileReaderAsync `CoreFileReader` implementation for reading or downloading binary files
+   * @param imageLoaderAsync `CoreImageLoader` implementation for reading and writing to and from PNG and JPEG formats
    * @param name An optional name specified when creating the object to help with debugging
    */
-  public constructor(public readonly fileReader: CoreFileReader, public readonly imageLoader: CoreImageLoader,
+  public constructor(public readonly fileReaderAsync: CoreFileReader, public readonly imageLoaderAsync: CoreImageLoader,
       name?: string) {
     super(EngineObjectType.Fim, name);
     this.resources = new ResourceTracker(this);
@@ -304,7 +304,7 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
     me.ensureNotDisposed();
 
     let result: TEngineImage;
-    await me.imageLoader(file, type, image => {
+    await me.imageLoaderAsync(file, type, image => {
       result = me.createEngineImage(parent ?? this, FimDimensions.fromObject(image), options ?? {}, name);
       result.loadFromImage(image);
     });
@@ -314,13 +314,13 @@ export abstract class EngineFimBase<TEngineImage extends EngineImage, TEngineSha
 
   public async createImageFromPngFileAsync(pngUrlOrPath: string, options?: FimImageOptions, name?: string,
       parent?: FimObject): Promise<TEngineImage> {
-    const pngFile = await this.fileReader(pngUrlOrPath);
+    const pngFile = await this.fileReaderAsync(pngUrlOrPath);
     return this.createImageFromPngAsync(pngFile, options, name ?? fileToName(pngUrlOrPath), parent);
   }
 
   public async createImageFromJpegFileAsync(jpegUrlOrPath: string, options?: FimImageOptions, name?: string,
       parent?: FimObject): Promise<TEngineImage> {
-    const jpegFile = await this.fileReader(jpegUrlOrPath);
+    const jpegFile = await this.fileReaderAsync(jpegUrlOrPath);
     return this.createImageFromJpegAsync(jpegFile, options, name ?? fileToName(jpegUrlOrPath), parent);
   }
 

--- a/packages/fim/src/engine/EngineImage.ts
+++ b/packages/fim/src/engine/EngineImage.ts
@@ -31,13 +31,13 @@ export abstract class EngineImage extends EngineObject implements FimDimensional
   /**
    * Constructor
    * @param parent Parent object
+   * @param dimensions Image dimensions
    * @param options Optional image options to override the parent FIM's defaults
-   * @param dimensions Optional image dimensions. Defaults to `maxImageDimensions` of the parent FIM object.
    * @param name An optional name specified when creating the object to help with debugging
    */
-  public constructor(parent: FimObject, options?: FimImageOptions, dimensions?: FimDimensions, name?: string) {
+  public constructor(parent: FimObject, dimensions: FimDimensions, options?: FimImageOptions, name?: string) {
     super(EngineObjectType.Image, name, parent);
-    this.dim = dimensions ?? this.rootObject.maxImageDimensions;
+    this.dim = dimensions;
     this.imageOptions = deepCopy(options) ?? {};
 
     const root = this.rootObject;
@@ -372,7 +372,7 @@ export abstract class EngineImage extends EngineObject implements FimDimensional
     if (shaderOrOperation.uniformsContainEngineImage(me)) {
       // Special case: We are using this image both as an input and and output. Using a single texture as both input and
       // output isn't supported by WebGL, but we work around this by creating a temporary WebGL texture.
-      const outputTexture = glCanvas.createCoreTexture(contentTexture.getOptions(), contentTexture.imageContent.dim);
+      const outputTexture = glCanvas.createCoreTexture(contentTexture.imageContent.dim, contentTexture.getOptions());
       try {
         root.resources.recordCreate(me, outputTexture);
         await shaderOrOperation.executeAsync(glCanvas, outputTexture, scaledDestCoords);
@@ -523,7 +523,7 @@ export abstract class EngineImage extends EngineObject implements FimDimensional
     // Slow case: Copy the desired portion of the image to a temporary 2D canvas while rescaling, then export the
     // temporary canvas. Rescaling pixel data in JavaScript is slow and doesn't do as good of a job of image
     // smoothing.
-    const temp = root.createCoreCanvas2D(me.contentCanvas.getOptions(), srcCoords.dim, `${me.handle}/RescaleHelper`);
+    const temp = root.createCoreCanvas2D(srcCoords.dim, me.contentCanvas.getOptions(), `${me.handle}/RescaleHelper`);
     try {
       root.resources.recordCreate(me, temp);
 

--- a/packages/fim/src/engine/EngineImage.ts
+++ b/packages/fim/src/engine/EngineImage.ts
@@ -359,6 +359,9 @@ export abstract class EngineImage extends EngineObject implements FimDimensional
       return shaderOrOperation.executeAsync(me, destCoords);
     }
 
+    // Ensure the WebGL canvas is large enough to handle this image. This function call will resize it if needed.
+    await root.allocateWebGLCanvasAsync(me.dim);
+
     // Handle defaults and validate coordinates
     destCoords = destCoords ?? FimRect.fromDimensions(me.dim);
     destCoords.validateIn(me);

--- a/packages/fim/src/engine/EngineImage.ts
+++ b/packages/fim/src/engine/EngineImage.ts
@@ -282,7 +282,7 @@ export abstract class EngineImage extends EngineObject implements FimDimensional
   private async loadFromFileAsync(file: Uint8Array, type: CoreMimeType, allowRescale: boolean): Promise<void> {
     const me = this;
 
-    return me.rootObject.imageLoader(file, type, image => {
+    return me.rootObject.imageLoaderAsync(file, type, image => {
       // If allowRescale is disabled, explicitly check the dimensions here. We can't pass allowRescale parameter down
       // to CoreCanvas2D.loadFromImage, because it may be a different set of dimensions due to auto-downscaling.
       const imageDimensions = FimDimensions.fromObject(image);
@@ -295,12 +295,12 @@ export abstract class EngineImage extends EngineObject implements FimDimensional
   }
 
   public async loadFromPngFileAsync(pngUrl: string, allowRescale?: boolean): Promise<void> {
-    const pngFile = await this.rootObject.fileReader(pngUrl);
+    const pngFile = await this.rootObject.fileReaderAsync(pngUrl);
     return this.loadFromPngAsync(pngFile, allowRescale);
   }
 
   public async loadFromJpegFileAsync(jpegUrl: string, allowRescale?: boolean): Promise<void> {
-    const jpegFile = await this.rootObject.fileReader(jpegUrl);
+    const jpegFile = await this.rootObject.fileReaderAsync(jpegUrl);
     return this.loadFromPngAsync(jpegFile, allowRescale);
   }
 

--- a/packages/fim/src/engine/EngineImage.ts
+++ b/packages/fim/src/engine/EngineImage.ts
@@ -242,7 +242,7 @@ export abstract class EngineImage extends EngineObject implements FimDimensional
       FimError.throwOnInvalidDimensions(dimensions, pixelData.length);
     }
 
-    me.contentCanvas.allocateContent(dimensions);
+    await me.contentCanvas.allocateContentAsync(dimensions);
     await me.contentCanvas.imageContent.loadPixelDataAsync(pixelData, dimensions);
     me.markCurrent(me.contentCanvas, true);
 
@@ -257,12 +257,12 @@ export abstract class EngineImage extends EngineObject implements FimDimensional
    * @param image Image object. The caller is responsible for first waiting for the `onload` event of the image before
    *    calling this function.
    */
-  public loadFromImage(image: ImageSource): void {
+  public async loadFromImageAsync(image: ImageSource): Promise<void> {
     const me = this;
     const optimizer = me.rootObject.optimizer;
     me.ensureNotDisposed();
 
-    me.contentCanvas.allocateContent(FimDimensions.fromObject(image));
+    await me.contentCanvas.allocateContentAsync(FimDimensions.fromObject(image));
     me.contentCanvas.imageContent.loadFromImage(image);
     me.markCurrent(me.contentCanvas, true);
 
@@ -282,7 +282,7 @@ export abstract class EngineImage extends EngineObject implements FimDimensional
   private async loadFromFileAsync(file: Uint8Array, type: CoreMimeType, allowRescale: boolean): Promise<void> {
     const me = this;
 
-    return me.rootObject.imageLoader(file, type, image => {
+    return me.rootObject.imageLoaderAsync(file, type, image => {
       // If allowRescale is disabled, explicitly check the dimensions here. We can't pass allowRescale parameter down
       // to CoreCanvas2D.loadFromImage, because it may be a different set of dimensions due to auto-downscaling.
       const imageDimensions = FimDimensions.fromObject(image);
@@ -290,7 +290,7 @@ export abstract class EngineImage extends EngineObject implements FimDimensional
         FimError.throwOnInvalidDimensions(me.dim, imageDimensions);
       }
 
-      me.loadFromImage(image);
+      return me.loadFromImageAsync(image);
     });
   }
 
@@ -363,11 +363,13 @@ export abstract class EngineImage extends EngineObject implements FimDimensional
     destCoords = destCoords ?? FimRect.fromDimensions(me.dim);
     destCoords.validateIn(me);
 
+    // Allocate or resize the WebGL canvas
+    const glCanvas = await root.getWebGLCanvas(me.dim);
+
     // By default, we leave it up to allocateOrPopulateContentAsync to decide whether the output image needs to be
     // populated based on the destination coordinates.
     await contentTexture.allocateOrPopulateContentAsync(destCoords, shaderOrOperation.hasNonDefaultVertices());
 
-    const glCanvas = root.getWebGLCanvas();
     const scaledDestCoords = destCoords.rescale(contentTexture.downscale);
     if (shaderOrOperation.uniformsContainEngineImage(me)) {
       // Special case: We are using this image both as an input and and output. Using a single texture as both input and

--- a/packages/fim/src/engine/EngineShader.ts
+++ b/packages/fim/src/engine/EngineShader.ts
@@ -9,6 +9,7 @@ import { FimObject } from '../api/FimObject';
 import { FimReleaseResourcesFlags } from '../api/FimReleaseResourcesFlags';
 import { FimShader } from '../api/FimShader';
 import { FimValue } from '../api/FimValue';
+import { CoreCanvasWebGL } from '../core/CoreCanvasWebGL';
 import { CoreShader } from '../core/CoreShader';
 import { CoreTexture } from '../core/CoreTexture';
 import { CoreValue } from '../core/CoreValue';
@@ -150,13 +151,14 @@ export class EngineShader extends EngineObject implements FimShader {
 
   /**
    * Executes a program. Callers must first set the constant and uniform values before calling this method.
-   * @param outputTexture Destination texture to render to. If unspecified, the output is rendered to the parent
-   *    CoreCanvasWebGL.
+   * @param glCanvas The `CoreCanvasWebGL` instance
+   * @param outputTexture Destination texture to render to. If unspecified, the output is rendered to `glCanvas`.
    * @param destCoords If set, renders the output to the specified destination coordinates using WebGL's viewport and
    *    scissor operations. By default, the destination is the full texture or canvas. Note that the coordinates use
    *    the top-left as the origin, to be consistent with 2D canvases, despite WebGL typically using bottom-left.
    */
-  public async executeAsync(outputTexture?: CoreTexture, destCoords?: FimRect): Promise<void> {
+  public async executeAsync(glCanvas: CoreCanvasWebGL, outputTexture?: CoreTexture, destCoords?: FimRect):
+      Promise<void> {
     const me = this;
     const root = me.rootObject;
     me.ensureNotDisposedAndHasContext();
@@ -167,7 +169,7 @@ export class EngineShader extends EngineObject implements FimShader {
     if (!shader) {
       // Create a new shader, set the constants, and compile it. We explicitly compile the program to catch any compiler
       // errors here before caching, rather than letting CoreShader automatically compile on first use.
-      shader = new CoreShader(root.getWebGLCanvas(), me.handle, me.fragmentShader, me.vertexShader);
+      shader = new CoreShader(glCanvas, me.handle, me.fragmentShader, me.vertexShader);
       shader.setConstants(me.constantValues);
       shader.compileProgram();
 

--- a/packages/fim/src/engine/ImageContent.ts
+++ b/packages/fim/src/engine/ImageContent.ts
@@ -7,10 +7,10 @@ import { CoreCanvas2D } from '../core/CoreCanvas2D';
 import { CoreCanvasOptions } from '../core/CoreCanvasOptions';
 import { CoreTexture } from '../core/CoreTexture';
 import { CoreTextureOptions } from '../core/CoreTextureOptions';
+import { EngineImage } from '../engine/EngineImage';
 import { FimDimensions } from '../primitives/FimDimensions';
 import { FimError } from '../primitives/FimError';
 import { FimRect } from '../primitives/FimRect';
-import { EngineImage } from '../internal';
 
 /**
  * Base class for any object containing the image contents
@@ -86,15 +86,17 @@ export abstract class ImageContentCommon<TContent extends CoreTexture | CoreCanv
     downscaleValues.push(maxOptionsSize / maxDim);
 
     // Check whether the image dimensions are larger than the parent FIM instance
-    if (!options.allowOversized && (dim.w > root.maxImageDimensions.w || dim.h > root.maxImageDimensions.h)) {
-      downscaleValues.push(root.maxImageDimensions.w / dim.w);
-      downscaleValues.push(root.maxImageDimensions.h / dim.h);
+    if (!options.allowOversized && (dim.w > engineOptions.maxImageDimensions.w ||
+        dim.h > engineOptions.maxImageDimensions.h)) {
+      downscaleValues.push(engineOptions.maxImageDimensions.w / dim.w);
+      downscaleValues.push(engineOptions.maxImageDimensions.h / dim.h);
 
       // Log a warning when this happens. It is likely a bug in the calling code if the requested FimImage dimensions
       // are larger than Fim.maxImageDimensions. If the caller truly wants this, they should consider setting
       // FimImageOptions.allowOversized to prevent it from getting automatically downscaled.
       if (!parentImage.autoDownscaleWarningLogged) {
-        root.writeWarning(parentImage, `Auto-downscale ${me.handle}: ${dim} > max (${root.maxImageDimensions})`);
+        root.writeWarning(parentImage,
+          `Auto-downscale ${me.handle}: ${dim} > max (${engineOptions.maxImageDimensions})`);
         parentImage.autoDownscaleWarningLogged = true;
       }
     }

--- a/packages/fim/src/engine/ImageContent.ts
+++ b/packages/fim/src/engine/ImageContent.ts
@@ -244,7 +244,7 @@ export class CanvasImageContent extends ImageContentCommon<CoreCanvas2D, CoreCan
   protected allocateContentInternal(dimensions: FimDimensions, options: CoreCanvasOptions): CoreCanvas2D {
     const root = this.parentImage.rootObject;
     root.optimizer.reserveCanvasMemory(dimensions.getArea() * 4);
-    return root.createCoreCanvas2D(options, dimensions, this.handle);
+    return root.createCoreCanvas2D(dimensions, options, this.handle);
   }
 
   protected async populateContentInternalAsync(): Promise<void> {
@@ -322,7 +322,7 @@ export class TextureImageContent extends ImageContentCommon<CoreTexture, CoreTex
     const root = me.parentImage.rootObject;
     const glCanvas = root.getWebGLCanvas();
     root.optimizer.reserveGLMemory(dimensions.getArea() * options.bpp * 0.5);
-    return glCanvas.createCoreTexture(options, dimensions, me.handle);
+    return glCanvas.createCoreTexture(dimensions, options, me.handle);
   }
 
   protected async populateContentInternalAsync(): Promise<void> {

--- a/packages/fim/src/engine/ImageContent.ts
+++ b/packages/fim/src/engine/ImageContent.ts
@@ -119,7 +119,7 @@ export abstract class ImageContentCommon<TContent extends CoreTexture | CoreCanv
    *    `imageOptions.preserveDownscaledDimensions` optimization and is ignored if this optimization is disabled.
    * @returns `this.imageContent`
    */
-  public allocateContent(dimensions?: FimDimensions): TContent {
+  public async allocateContentAsync(dimensions?: FimDimensions): Promise<TContent> {
     const me = this;
     const parentImage = me.parentImage;
     const root = parentImage.rootObject;
@@ -140,7 +140,7 @@ export abstract class ImageContentCommon<TContent extends CoreTexture | CoreCanv
 
     // Create the underlying canvas or texture
     const options = me.getOptions();
-    const content = me.imageContent = me.allocateContentInternal(dd.scaledDimensions, options);
+    const content = me.imageContent = await me.allocateContentInternalAsync(dd.scaledDimensions, options);
     me.downscale = dd.downscale;
 
     // Record the object creation
@@ -155,7 +155,7 @@ export abstract class ImageContentCommon<TContent extends CoreTexture | CoreCanv
    * @param options Object creation options
    * @returns New `TContent`
    */
-  protected abstract allocateContentInternal(dimensions: FimDimensions, options: TOptions): TContent;
+  protected abstract allocateContentInternalAsync(dimensions: FimDimensions, options: TOptions): Promise<TContent>;
 
   /**
    * Ensures `imageContent` is current and contains the current image data. This function should be called before
@@ -202,7 +202,7 @@ export abstract class ImageContentCommon<TContent extends CoreTexture | CoreCanv
       // The destination is the full image. The current image contents will be erased, so use the opportunity to update
       // the image options or use a smaller canvas than is actually needed (the preserveDownscaledDimensions
       // optimization).
-      me.allocateContent(dimensions);
+      await me.allocateContentAsync(dimensions);
     } else {
       // The destination is not the full image. Some of the current image is required. Ensure the canvas is populated,
       // and throw an exception if the current image is uninitialized.
@@ -243,7 +243,8 @@ export class CanvasImageContent extends ImageContentCommon<CoreCanvas2D, CoreCan
     return {};
   }
 
-  protected allocateContentInternal(dimensions: FimDimensions, options: CoreCanvasOptions): CoreCanvas2D {
+  protected async allocateContentInternalAsync(dimensions: FimDimensions, options: CoreCanvasOptions):
+      Promise<CoreCanvas2D> {
     const root = this.parentImage.rootObject;
     root.optimizer.reserveCanvasMemory(dimensions.getArea() * 4);
     return root.createCoreCanvas2D(dimensions, options, this.handle);
@@ -259,11 +260,12 @@ export class CanvasImageContent extends ImageContentCommon<CoreCanvas2D, CoreCan
 
     if (contentFillColor.isCurrent) {
       // Copy the fill color to the canvas to make it current
-      me.allocateContent().fillSolid(contentFillColor.imageContent);
+      const content = await me.allocateContentAsync();
+      content.fillSolid(contentFillColor.imageContent);
     } else if (contentTexture.isCurrent) {
       // First, get the WebGL canvas. The getWebGLCanvas() call will allocate or resize it if necessary.
       const srcTexture = contentTexture.imageContent;
-      const glCanvas = root.getWebGLCanvas();
+      const glCanvas = await root.getWebGLCanvas(srcTexture.dim);
 
       // Calculate the coordinates to use on the WebGL canvas
       const glCanvasDim = srcTexture.dim.fitInside(glCanvas.dim).toFloor();
@@ -273,7 +275,8 @@ export class CanvasImageContent extends ImageContentCommon<CoreCanvas2D, CoreCan
       glCanvas.copyFrom(srcTexture, undefined, glCanvasCoords);
 
       // Copy the WebGL canvas to a 2D canvas
-      await me.allocateContent(glCanvasDim).copyFromAsync(glCanvas, glCanvasCoords);
+      const content = await me.allocateContentAsync(glCanvasDim);
+      await content.copyFromAsync(glCanvas, glCanvasCoords);
 
       optimizer.recordImageRead(parentImage, ImageType.Texture);
     }
@@ -319,10 +322,11 @@ export class TextureImageContent extends ImageContentCommon<CoreTexture, CoreTex
     return dd;
   }
 
-  protected allocateContentInternal(dimensions: FimDimensions, options: CoreTextureOptions): CoreTexture {
+  protected async allocateContentInternalAsync(dimensions: FimDimensions, options: CoreTextureOptions):
+      Promise<CoreTexture> {
     const me = this;
     const root = me.parentImage.rootObject;
-    const glCanvas = root.getWebGLCanvas();
+    const glCanvas = await root.getWebGLCanvas(dimensions);
     root.optimizer.reserveGLMemory(dimensions.getArea() * options.bpp * 0.5);
     return glCanvas.createCoreTexture(dimensions, options, me.handle);
   }
@@ -337,11 +341,13 @@ export class TextureImageContent extends ImageContentCommon<CoreTexture, CoreTex
 
     if (contentFillColor.isCurrent) {
       // Fill texture with solid color
-      me.allocateContent().fillSolid(contentFillColor.imageContent);
+      const content = await me.allocateContentAsync();
+      content.fillSolid(contentFillColor.imageContent);
     } else if (contentCanvas.isCurrent) {
       // Copy canvas to texture
       const srcImage = contentCanvas.imageContent;
-      await me.allocateContent(srcImage.dim).copyFromAsync(srcImage);
+      const content = await me.allocateContentAsync(srcImage.dim);
+      await content.copyFromAsync(srcImage);
       optimizer.recordImageRead(parentImage, ImageType.Canvas);
     }
 

--- a/packages/fim/src/internal/index.ts
+++ b/packages/fim/src/internal/index.ts
@@ -10,6 +10,7 @@
 
 export { defaultEngineOptions } from '../api/FimEngineOptions';
 export { defaultImageOptions, mergeImageOptions } from '../api/FimImageOptions';
+export { CoreCallbackCollection } from '../core/CoreCallbackCollection';
 export { CoreCanvas } from '../core/CoreCanvas';
 export { CoreCanvas2D } from '../core/CoreCanvas2D';
 export { CoreCanvasOptions } from '../core/CoreCanvasOptions';

--- a/packages/fim/src/ops/FimOpDownscale.ts
+++ b/packages/fim/src/ops/FimOpDownscale.ts
@@ -122,7 +122,7 @@ export class FimOpDownscale extends FimOperationShader {
       allowOversized: true,
       sampling: FimTextureSampling.Linear
     };
-    return usingAsync(me.rootObject.createImage(options, nextDimensions, 'DownscaleTemp'), async temp => {
+    return usingAsync(me.rootObject.createImage(nextDimensions, options, 'DownscaleTemp'), async temp => {
       await me.executeInternalAsync(inputImage, temp);
       await me.executeInternalAsync(temp, outputImage, destCoords);
     });

--- a/packages/fim/src/primitives/FimDimensions.ts
+++ b/packages/fim/src/primitives/FimDimensions.ts
@@ -123,11 +123,11 @@ export class FimDimensions extends FimGeometry {
     return new FimDimensions(object.width, object.height);
   }
 
-  public static min(d1: FimDimensions, d2: FimDimensions): FimDimensions {
+  public static fromMin(d1: FimDimensions, d2: FimDimensions): FimDimensions {
     return new FimDimensions(Math.min(d1.w, d2.w), Math.min(d1.h, d2.h));
   }
 
-  public static max(d1: FimDimensions, d2: FimDimensions): FimDimensions {
+  public static fromMax(d1: FimDimensions, d2: FimDimensions): FimDimensions {
     return new FimDimensions(Math.max(d1.w, d2.w), Math.max(d1.h, d2.h));
   }
 

--- a/packages/fim/src/primitives/__tests__/FimDimensions.test.ts
+++ b/packages/fim/src/primitives/__tests__/FimDimensions.test.ts
@@ -48,14 +48,14 @@ describe('FimDimensions', () => {
   it('Calculates minimum', () => {
     const dim1 = FimDimensions.fromWidthHeight(300, 400);
     const dim2 = FimDimensions.fromWidthHeight(200, 500);
-    const dim3 = FimDimensions.min(dim1, dim2);
+    const dim3 = FimDimensions.fromMin(dim1, dim2);
     expect(dim3).toEqual(FimDimensions.fromWidthHeight(200, 400));
   });
 
   it('Calculates maximum', () => {
     const dim1 = FimDimensions.fromWidthHeight(300, 400);
     const dim2 = FimDimensions.fromWidthHeight(200, 500);
-    const dim3 = FimDimensions.max(dim1, dim2);
+    const dim3 = FimDimensions.fromMax(dim1, dim2);
     expect(dim3).toEqual(FimDimensions.fromWidthHeight(300, 500));
   });
 

--- a/samples/brightness-contrast.html
+++ b/samples/brightness-contrast.html
@@ -15,22 +15,21 @@
     <script>
 $(async () => {
   // Initialize the global FIM instance
-  const fim = FimBrowserFactory.create(FimDimensions.fromWidthHeight(1920, 1080));
+  const fim = FimBrowserFactory.create();
 
   // Load the sample image
   const url = 'https://www.leosingleton.com/sample-images/jellyfish.jpg';
   const inputImage = await fim.createImageFromJpegFileAsync(url, { autoBackup: true, bpp: 8, glReadOnly: true });
+  const dimensions = inputImage.dim;
 
   // Create the brightness and contrast operation
   const brightnessContrast = new FimOpBrightnessContrast(fim);
 
   // Create the output image
-  const outputImage = fim.createImage({}, inputImage.dim, 'outputImage');
+  const outputImage = fim.createImage(dimensions, {}, 'outputImage');
 
-  // Get and scale the output canvas
+  // Get the output canvas
   const canvas = $('#output').get(0);
-  canvas.width = outputImage.dim.w;
-  canvas.height = outputImage.dim.h;
 
   // Start the animation loop
   requestAnimationFrame(renderOneFrame);
@@ -38,7 +37,7 @@ $(async () => {
   async function renderOneFrame() {
     try {
       // Adjust canvas dimensions to support high DPR displays
-      enableHighDprCanvas(canvas, outputImage.dim);
+      enableHighDprCanvas(canvas, dimensions);
 
       // Cycle back and forth brightness every 5 seconds and contrast every 7 seconds
       const brightness = getAnimationValue(5000, -1, 1);

--- a/samples/gaussian-blur.html
+++ b/samples/gaussian-blur.html
@@ -15,22 +15,21 @@
     <script>
 $(async () => {
   // Initialize the global FIM instance
-  const fim = FimBrowserFactory.create(FimDimensions.fromWidthHeight(1920, 1080));
+  const fim = FimBrowserFactory.create();
 
   // Load the sample image
   const url = 'https://www.leosingleton.com/sample-images/carmel.jpg';
   const inputImage = await fim.createImageFromJpegFileAsync(url, { autoBackup: true, bpp: 8, glReadOnly: true });
+  const dimensions = inputImage.dim;
 
   // Create the Gaussian Blur operation
   const blur = new FimOpGaussianBlur(fim, true);
 
   // Create the output image
-  const outputImage = fim.createImage({}, inputImage.dim, 'outputImage');
+  const outputImage = fim.createImage(dimensions, {}, 'outputImage');
 
-  // Get and scale the output canvas
+  // Get the output canvas
   const canvas = $('#output').get(0);
-  canvas.width = outputImage.dim.w;
-  canvas.height = outputImage.dim.h;
 
   // Start the animation loop
   requestAnimationFrame(renderOneFrame);
@@ -38,7 +37,7 @@ $(async () => {
   async function renderOneFrame() {
     try {
       // Adjust canvas dimensions to support high DPR displays
-      enableHighDprCanvas(canvas, outputImage.dim);
+      enableHighDprCanvas(canvas, dimensions);
 
       // Cycle sigma from 0 to 10 every 5 seconds
       const sigma = getAnimationValue(5000, 0, 10);

--- a/samples/transform2d.html
+++ b/samples/transform2d.html
@@ -15,22 +15,21 @@
     <script>
 $(async () => {
   // Initialize the global FIM instance
-  const fim = FimBrowserFactory.create(FimDimensions.fromWidthHeight(1920, 1080));
+  const fim = FimBrowserFactory.create();
 
   // Load the sample image
   const url = 'https://www.leosingleton.com/sample-images/jellyfish.jpg';
   const inputImage = await fim.createImageFromJpegFileAsync(url, { autoBackup: true, bpp: 8, glReadOnly: true });
+  const dimensions = inputImage.dim;
 
   // Create the brightness and contrast operation
   const copy = new FimOpCopy(fim);
 
   // Create the output image
-  const outputImage = fim.createImage({}, inputImage.dim, 'outputImage');
+  const outputImage = fim.createImage(dimensions, {}, 'outputImage');
 
-  // Get and scale the output canvas
+  // Get the output canvas
   const canvas = $('#output').get(0);
-  canvas.width = outputImage.dim.w;
-  canvas.height = outputImage.dim.h;
 
   // Start the animation loop
   requestAnimationFrame(renderOneFrame);
@@ -38,7 +37,7 @@ $(async () => {
   async function renderOneFrame() {
     try {
       // Adjust canvas dimensions to support high DPR displays
-      enableHighDprCanvas(canvas, outputImage.dim);
+      enableHighDprCanvas(canvas, dimensions);
 
       // Rotate 360 degrees every 5 seconds
       const angle = getAnimationValue(5000, 0, Math.PI * 2);
@@ -53,11 +52,11 @@ $(async () => {
       // Calculate the vertex transformation matrix. Note that the operations are applied in reverse order due to the
       // way matrix multiplication works. Translate, then rotate, then scale.
       const matrix = new FimTransform2D();
-      matrix.rescale(inputImage.dim.w, inputImage.dim.h);
+      matrix.rescale(dimensions.w, dimensions.h);
       matrix.rescale(scale, scale);
       matrix.rotation(angle);
-      matrix.translation(tx * inputImage.dim.w, ty * inputImage.dim.h);
-      matrix.rescale(1 / inputImage.dim.w, 1 / inputImage.dim.h);
+      matrix.translation(tx * dimensions.w, ty * dimensions.h);
+      matrix.rescale(1 / dimensions.w, 1 / dimensions.h);
 
       measureFrameStart();
 

--- a/samples/transform3d.html
+++ b/samples/transform3d.html
@@ -15,22 +15,21 @@
     <script>
 $(async () => {
   // Initialize the global FIM instance
-  const fim = FimBrowserFactory.create(FimDimensions.fromWidthHeight(1920, 1080));
+  const fim = FimBrowserFactory.create();
 
   // Load the sample image
   const url = 'https://www.leosingleton.com/sample-images/jellyfish.jpg';
   const inputImage = await fim.createImageFromJpegFileAsync(url, { autoBackup: true, bpp: 8, glReadOnly: true });
+  const dimensions = inputImage.dim;
 
   // Create the brightness and contrast operation
   const copy = new FimOpCopy(fim);
 
   // Create the output image
-  const outputImage = fim.createImage({}, inputImage.dim, 'outputImage');
+  const outputImage = fim.createImage(dimensions, {}, 'outputImage');
 
-  // Get and scale the output canvas
+  // Get the output canvas
   const canvas = $('#output').get(0);
-  canvas.width = outputImage.dim.w;
-  canvas.height = outputImage.dim.h;
 
   // Start the animation loop
   requestAnimationFrame(renderOneFrame);
@@ -38,7 +37,7 @@ $(async () => {
   async function renderOneFrame() {
     try {
       // Adjust canvas dimensions to support high DPR displays
-      enableHighDprCanvas(canvas, outputImage.dim);
+      enableHighDprCanvas(canvas, dimensions);
 
       // Rotate X-axis 360 degrees every 5 seconds, Y-axis every 12 seconds, and Z-axis every 60 seconds
       const angleX = getAnimationValue(5000, 0, Math.PI * 2);
@@ -48,11 +47,11 @@ $(async () => {
       // Calculate the vertex transformation matrix. Note that the operations are applied in reverse order due to the
       // way matrix multiplication works. Translate, then rotate, then scale.
       const matrix = new FimTransform3D();
-      matrix.rescale(inputImage.dim.w, inputImage.dim.h, inputImage.dim.w);
+      matrix.rescale(dimensions.w, dimensions.h, dimensions.w);
       matrix.rotateX(angleX);
       matrix.rotateY(angleY);
       matrix.rotateZ(angleZ);
-      matrix.rescale(1 / inputImage.dim.w, 1 / inputImage.dim.h, 1 / inputImage.dim.w);
+      matrix.rescale(1 / dimensions.w, 1 / dimensions.h, 1 / dimensions.w);
 
       measureFrameStart();
 

--- a/samples/unsharp-mask.html
+++ b/samples/unsharp-mask.html
@@ -15,19 +15,20 @@
     <script>
 $(async () => {
   // Initialize the global FIM instance
-  const fim = FimBrowserFactory.create(FimDimensions.fromWidthHeight(1920, 1080));
+  const fim = FimBrowserFactory.create();
 
   // Load the sample image
   const url = 'https://www.leosingleton.com/sample-images/carmel.jpg';
   const inputImage = await fim.createImageFromJpegFileAsync(url, { autoBackup: true, bpp: 8, glReadOnly: true });
+  const dimensions = inputImage.dim;
 
   // Create the unsharp mask operation
   const unsharpMask = new FimOpUnsharpMask(fim, true);
 
   // Create the output image
-  const outputImage = fim.createImage({}, inputImage.dim, 'outputImage');
+  const outputImage = fim.createImage(dimensions, {}, 'outputImage');
 
-  // Get and scale the output canvas
+  // Get the output canvas
   const canvas = $('#output').get(0);
 
   // Start the animation loop
@@ -36,7 +37,7 @@ $(async () => {
   async function renderOneFrame() {
     try {
       // Adjust canvas dimensions to support high DPR displays
-      enableHighDprCanvas(canvas, outputImage.dim);
+      enableHighDprCanvas(canvas, dimensions);
 
       // Cycle back and forth every 3 seconds
       const amount = getAnimationValue(3000, 0, 5);


### PR DESCRIPTION
In FIMv1 and earlier versions of v2, the caller had to provide a set of dimensions when instantiating the FIM library. The WebGL canvas backing the library was set to this size and could not be rescaled. Now, the size is determined dynamically and resized as larger images are created.